### PR TITLE
Fixes #131

### DIFF
--- a/api/src/test/java/org/motechproject/nms/api/osgi/CallDetailsControllerBundleIT.java
+++ b/api/src/test/java/org/motechproject/nms/api/osgi/CallDetailsControllerBundleIT.java
@@ -4,10 +4,12 @@ import com.google.common.base.Joiner;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
+import org.joda.time.DateTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.motechproject.nms.flw.domain.CallDetailRecord;
 import org.motechproject.nms.flw.domain.FrontLineWorker;
+import org.motechproject.nms.flw.domain.FrontLineWorkerStatus;
 import org.motechproject.nms.flw.repository.CallContentDataService;
 import org.motechproject.nms.flw.repository.CallDetailRecordDataService;
 import org.motechproject.nms.flw.repository.FrontLineWorkerDataService;
@@ -29,7 +31,10 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 
 
@@ -66,6 +71,13 @@ public class CallDetailsControllerBundleIT extends BasePaxIT {
     }
 
     private void cleanAllData() {
+        for (FrontLineWorker flw: frontLineWorkerDataService.retrieveAll()) {
+            flw.setStatus(FrontLineWorkerStatus.INVALID);
+            flw.setInvalidationDate(new DateTime().withDate(2011, 8, 1));
+
+            frontLineWorkerDataService.update(flw);
+        }
+
         serviceUsageCapDataService.deleteAll();
         serviceUsageDataService.deleteAll();
         callDetailRecordDataService.deleteAll();

--- a/api/src/test/java/org/motechproject/nms/api/osgi/KilkariControllerBundleIT.java
+++ b/api/src/test/java/org/motechproject/nms/api/osgi/KilkariControllerBundleIT.java
@@ -124,6 +124,13 @@ public class KilkariControllerBundleIT extends BasePaxIT {
     private SubscriptionPack gPack2;
 
     private void cleanAllData() {
+        for (Subscription subscription: subscriptionDataService.retrieveAll()) {
+            subscription.setStatus(SubscriptionStatus.COMPLETED);
+            subscription.setEndDate(new DateTime().withDate(2011, 8, 1));
+
+            subscriptionDataService.update(subscription);
+        }
+
         subscriptionDataService.deleteAll();
         subscriptionPackDataService.deleteAll();
         subscriptionPackMessageDataService.deleteAll();

--- a/api/src/test/java/org/motechproject/nms/api/osgi/KilkariControllerBundleIT.java
+++ b/api/src/test/java/org/motechproject/nms/api/osgi/KilkariControllerBundleIT.java
@@ -16,6 +16,8 @@ import org.motechproject.nms.api.web.contract.kilkari.InboxCallDetailsRequest;
 import org.motechproject.nms.api.web.contract.kilkari.InboxResponse;
 import org.motechproject.nms.api.web.contract.kilkari.InboxSubscriptionDetailResponse;
 import org.motechproject.nms.api.web.contract.kilkari.SubscriptionRequest;
+import org.motechproject.nms.flw.domain.FrontLineWorker;
+import org.motechproject.nms.flw.domain.FrontLineWorkerStatus;
 import org.motechproject.nms.flw.repository.FrontLineWorkerDataService;
 import org.motechproject.nms.flw.repository.ServiceUsageCapDataService;
 import org.motechproject.nms.flw.repository.ServiceUsageDataService;
@@ -124,6 +126,13 @@ public class KilkariControllerBundleIT extends BasePaxIT {
     private SubscriptionPack gPack2;
 
     private void cleanAllData() {
+        for (FrontLineWorker flw: frontLineWorkerDataService.retrieveAll()) {
+            flw.setStatus(FrontLineWorkerStatus.INVALID);
+            flw.setInvalidationDate(new DateTime().withDate(2011, 8, 1));
+
+            frontLineWorkerDataService.update(flw);
+        }
+
         for (Subscription subscription: subscriptionDataService.retrieveAll()) {
             subscription.setStatus(SubscriptionStatus.COMPLETED);
             subscription.setEndDate(new DateTime().withDate(2011, 8, 1));

--- a/api/src/test/java/org/motechproject/nms/api/osgi/LanguageControllerBundleIT.java
+++ b/api/src/test/java/org/motechproject/nms/api/osgi/LanguageControllerBundleIT.java
@@ -4,6 +4,7 @@ import org.apache.commons.httpclient.HttpStatus;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.joda.time.DateTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.motechproject.nms.api.web.contract.UserLanguageRequest;
@@ -38,7 +39,9 @@ import org.ops4j.pax.exam.spi.reactors.PerSuite;
 import javax.inject.Inject;
 import java.io.IOException;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerSuite.class)
@@ -75,6 +78,13 @@ public class LanguageControllerBundleIT extends BasePaxIT {
     private FrontLineWorkerDataService frontLineWorkerDataService;
 
     private void cleanAllData() {
+        for (FrontLineWorker flw: frontLineWorkerDataService.retrieveAll()) {
+            flw.setStatus(FrontLineWorkerStatus.INVALID);
+            flw.setInvalidationDate(new DateTime().withDate(2011, 8, 1));
+
+            frontLineWorkerDataService.update(flw);
+        }
+
         frontLineWorkerDataService.deleteAll();
         serviceUsageCapDataService.deleteAll();
         languageLocationDataService.deleteAll();

--- a/api/src/test/java/org/motechproject/nms/api/osgi/UserControllerBundleIT.java
+++ b/api/src/test/java/org/motechproject/nms/api/osgi/UserControllerBundleIT.java
@@ -28,9 +28,11 @@ import org.motechproject.nms.flw.repository.WhitelistEntryDataService;
 import org.motechproject.nms.flw.repository.WhitelistStateDataService;
 import org.motechproject.nms.flw.service.FrontLineWorkerService;
 import org.motechproject.nms.kilkari.domain.Subscriber;
+import org.motechproject.nms.kilkari.domain.Subscription;
 import org.motechproject.nms.kilkari.domain.SubscriptionOrigin;
 import org.motechproject.nms.kilkari.domain.SubscriptionPack;
 import org.motechproject.nms.kilkari.domain.SubscriptionPackType;
+import org.motechproject.nms.kilkari.domain.SubscriptionStatus;
 import org.motechproject.nms.kilkari.repository.SubscriberDataService;
 import org.motechproject.nms.kilkari.repository.SubscriptionDataService;
 import org.motechproject.nms.kilkari.repository.SubscriptionPackDataService;
@@ -68,7 +70,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -141,6 +145,13 @@ public class UserControllerBundleIT extends BasePaxIT {
 
     // TODO: Clean up data creation and cleanup
     private void cleanAllData() {
+        for (Subscription subscription: subscriptionDataService.retrieveAll()) {
+            subscription.setStatus(SubscriptionStatus.COMPLETED);
+            subscription.setEndDate(new DateTime().withDate(2011, 8, 1));
+
+            subscriptionDataService.update(subscription);
+        }
+
         whitelistEntryDataService.deleteAll();
         whitelistStateDataService.deleteAll();
         serviceUsageCapDataService.deleteAll();

--- a/api/src/test/java/org/motechproject/nms/api/osgi/UserControllerBundleIT.java
+++ b/api/src/test/java/org/motechproject/nms/api/osgi/UserControllerBundleIT.java
@@ -16,6 +16,7 @@ import org.motechproject.nms.api.web.contract.FlwUserResponse;
 import org.motechproject.nms.api.web.contract.UserLanguageRequest;
 import org.motechproject.nms.api.web.contract.kilkari.KilkariUserResponse;
 import org.motechproject.nms.flw.domain.FrontLineWorker;
+import org.motechproject.nms.flw.domain.FrontLineWorkerStatus;
 import org.motechproject.nms.flw.domain.ServiceUsage;
 import org.motechproject.nms.flw.domain.ServiceUsageCap;
 import org.motechproject.nms.flw.domain.WhitelistEntry;
@@ -145,6 +146,13 @@ public class UserControllerBundleIT extends BasePaxIT {
 
     // TODO: Clean up data creation and cleanup
     private void cleanAllData() {
+        for (FrontLineWorker flw: frontLineWorkerDataService.retrieveAll()) {
+            flw.setStatus(FrontLineWorkerStatus.INVALID);
+            flw.setInvalidationDate(new DateTime().withDate(2011, 8, 1));
+
+            frontLineWorkerDataService.update(flw);
+        }
+
         for (Subscription subscription: subscriptionDataService.retrieveAll()) {
             subscription.setStatus(SubscriptionStatus.COMPLETED);
             subscription.setEndDate(new DateTime().withDate(2011, 8, 1));

--- a/flw/src/main/java/org/motechproject/nms/flw/domain/FrontLineWorker.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/domain/FrontLineWorker.java
@@ -1,5 +1,6 @@
 package org.motechproject.nms.flw.domain;
 
+import org.joda.time.DateTime;
 import org.motechproject.mds.annotations.Entity;
 import org.motechproject.mds.annotations.Field;
 import org.motechproject.nms.region.domain.District;
@@ -35,6 +36,9 @@ public class FrontLineWorker {
 
     @Field
     private FrontLineWorkerStatus status;
+
+    @Field
+    private DateTime invalidationDate;
 
     @Field
     private LanguageLocation languageLocation;
@@ -98,6 +102,20 @@ public class FrontLineWorker {
 
     public void setStatus(FrontLineWorkerStatus status) {
         this.status = status;
+
+        if (this.status == FrontLineWorkerStatus.INVALID) {
+            setInvalidationDate(new DateTime());
+        } else {
+            setInvalidationDate(null);
+        }
+    }
+
+    public DateTime getInvalidationDate() {
+        return invalidationDate;
+    }
+
+    public void setInvalidationDate(DateTime invalidationDate) {
+        this.invalidationDate = invalidationDate;
     }
 
     public LanguageLocation getLanguageLocation() {

--- a/flw/src/main/java/org/motechproject/nms/flw/service/FrontLineWorkerService.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/service/FrontLineWorkerService.java
@@ -1,5 +1,7 @@
 package org.motechproject.nms.flw.service;
 
+import org.motechproject.mds.annotations.InstanceLifecycleListener;
+import org.motechproject.mds.domain.InstanceLifecycleListenerType;
 import org.motechproject.nms.flw.domain.FrontLineWorker;
 
 import java.util.List;
@@ -18,4 +20,13 @@ public interface FrontLineWorkerService {
     void update(FrontLineWorker record);
 
     void delete(FrontLineWorker record);
+
+    /**
+     * Lifecycle listener that verifies a Front Line Worker can only be deleted if it is invalid
+     * and has been in that state for 6 weeks
+     *
+     * @param frontLineWorker
+     */
+    @InstanceLifecycleListener(InstanceLifecycleListenerType.PRE_DELETE)
+    void deleteAllowed(FrontLineWorker frontLineWorker);
 }

--- a/flw/src/main/java/org/motechproject/nms/flw/service/impl/FrontLineWorkerServiceImpl.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/service/impl/FrontLineWorkerServiceImpl.java
@@ -1,5 +1,7 @@
 package org.motechproject.nms.flw.service.impl;
 
+import org.joda.time.DateTime;
+import org.joda.time.Weeks;
 import org.motechproject.nms.flw.domain.FrontLineWorker;
 import org.motechproject.nms.flw.domain.FrontLineWorkerStatus;
 import org.motechproject.nms.flw.repository.FrontLineWorkerDataService;
@@ -87,5 +89,22 @@ public class FrontLineWorkerServiceImpl implements FrontLineWorkerService {
     @Override
     public void delete(FrontLineWorker record) {
         frontLineWorkerDataService.delete(record);
+    }
+
+    @Override
+    public void deleteAllowed(FrontLineWorker frontLineWorker) {
+        DateTime now = new DateTime();
+
+        if (frontLineWorker.getStatus() != FrontLineWorkerStatus.INVALID) {
+            throw new IllegalStateException("Can not delete a valid FLW");
+        }
+
+        if (frontLineWorker.getInvalidationDate() == null) {
+            throw new IllegalStateException("FLW in invalid state with null invalidation date");
+        }
+
+        if (Math.abs(Weeks.weeksBetween(now, frontLineWorker.getInvalidationDate()).getWeeks()) < 6) {
+            throw new IllegalStateException("FLW must be in invalid state for 6 weeks before deleting");
+        }
     }
 }

--- a/flw/src/test/java/org/motechproject/nms/flw/osgi/IntegrationTests.java
+++ b/flw/src/test/java/org/motechproject/nms/flw/osgi/IntegrationTests.java
@@ -13,5 +13,5 @@ import org.junit.runners.Suite;
         WhiteListServiceBundleIT.class,
         FrontLineWorkerServiceBundleIT.class
 })
-public class FrontLineWorkerIntegrationTests {
+public class IntegrationTests {
 }

--- a/flw/src/test/java/org/motechproject/nms/flw/osgi/ServiceUsageServiceBundleIT.java
+++ b/flw/src/test/java/org/motechproject/nms/flw/osgi/ServiceUsageServiceBundleIT.java
@@ -4,6 +4,7 @@ import org.joda.time.DateTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.motechproject.nms.flw.domain.FrontLineWorker;
+import org.motechproject.nms.flw.domain.FrontLineWorkerStatus;
 import org.motechproject.nms.flw.domain.ServiceUsage;
 import org.motechproject.nms.flw.repository.FrontLineWorkerDataService;
 import org.motechproject.nms.flw.repository.ServiceUsageDataService;
@@ -43,6 +44,13 @@ public class ServiceUsageServiceBundleIT extends BasePaxIT {
     private ServiceUsageService serviceUsageService;
 
     private void setupData() {
+        for (FrontLineWorker flw: frontLineWorkerDataService.retrieveAll()) {
+            flw.setStatus(FrontLineWorkerStatus.INVALID);
+            flw.setInvalidationDate(new DateTime().withDate(2011, 8, 1));
+
+            frontLineWorkerDataService.update(flw);
+        }
+
         serviceUsageDataService.deleteAll();
         frontLineWorkerDataService.deleteAll();
     }
@@ -93,7 +101,15 @@ public class ServiceUsageServiceBundleIT extends BasePaxIT {
         serviceUsageDataService.delete(differentFLW);
         serviceUsageDataService.delete(recordOne);
         serviceUsageDataService.delete(recordTwo);
+
+        flw.setStatus(FrontLineWorkerStatus.INVALID);
+        flw.setInvalidationDate(new DateTime().withDate(2011, 8, 1));
+        frontLineWorkerService.update(flw);
         frontLineWorkerService.delete(flw);
+
+        flwIgnored.setStatus(FrontLineWorkerStatus.INVALID);
+        flwIgnored.setInvalidationDate(new DateTime().withDate(2011, 8, 1));
+        frontLineWorkerService.update(flwIgnored);
         frontLineWorkerService.delete(flwIgnored);
     }
 
@@ -112,6 +128,10 @@ public class ServiceUsageServiceBundleIT extends BasePaxIT {
         assertEquals(0, serviceUsage.getWelcomePrompt());
 
         serviceUsageDataService.delete(serviceUsage);
+
+        flw.setStatus(FrontLineWorkerStatus.INVALID);
+        flw.setInvalidationDate(new DateTime().withDate(2011, 8, 1));
+        frontLineWorkerService.update(flw);
         frontLineWorkerService.delete(flw);
     }
 

--- a/imi/src/test/java/org/motechproject/nms/imi/it/CdrFileServiceBundleIT.java
+++ b/imi/src/test/java/org/motechproject/nms/imi/it/CdrFileServiceBundleIT.java
@@ -1,5 +1,6 @@
 package org.motechproject.nms.imi.it;
 
+import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -8,8 +9,11 @@ import org.motechproject.nms.imi.service.CdrFileService;
 import org.motechproject.nms.imi.service.SettingsService;
 import org.motechproject.nms.imi.service.contract.ParseResults;
 import org.motechproject.nms.imi.web.contract.FileInfo;
+import org.motechproject.nms.kilkari.domain.Subscription;
+import org.motechproject.nms.kilkari.domain.SubscriptionStatus;
 import org.motechproject.nms.kilkari.repository.CallRetryDataService;
 import org.motechproject.nms.kilkari.repository.SubscriberDataService;
+import org.motechproject.nms.kilkari.repository.SubscriptionDataService;
 import org.motechproject.nms.kilkari.service.SubscriptionService;
 import org.motechproject.nms.region.repository.CircleDataService;
 import org.motechproject.nms.region.repository.DistrictDataService;
@@ -42,6 +46,9 @@ public class CdrFileServiceBundleIT extends BasePaxIT {
     private SubscriptionService subscriptionService;
 
     @Inject
+    private SubscriptionDataService subscriptionDataService;
+
+    @Inject
     private SubscriberDataService subscriberDataService;
 
     @Inject
@@ -70,6 +77,13 @@ public class CdrFileServiceBundleIT extends BasePaxIT {
 
     @Before
     public void cleanupDatabase() {
+        for (Subscription subscription: subscriptionDataService.retrieveAll()) {
+            subscription.setStatus(SubscriptionStatus.COMPLETED);
+            subscription.setEndDate(new DateTime().withDate(2011, 8, 1));
+
+            subscriptionDataService.update(subscription);
+        }
+
         subscriptionService.deleteAll();
         subscriberDataService.deleteAll();
         languageLocationDataService.deleteAll();

--- a/imi/src/test/java/org/motechproject/nms/imi/it/TargetFileServiceBundleIT.java
+++ b/imi/src/test/java/org/motechproject/nms/imi/it/TargetFileServiceBundleIT.java
@@ -14,8 +14,10 @@ import org.motechproject.nms.kilkari.domain.Subscriber;
 import org.motechproject.nms.kilkari.domain.Subscription;
 import org.motechproject.nms.kilkari.domain.SubscriptionOrigin;
 import org.motechproject.nms.kilkari.domain.SubscriptionPack;
+import org.motechproject.nms.kilkari.domain.SubscriptionStatus;
 import org.motechproject.nms.kilkari.repository.CallRetryDataService;
 import org.motechproject.nms.kilkari.repository.SubscriberDataService;
+import org.motechproject.nms.kilkari.repository.SubscriptionDataService;
 import org.motechproject.nms.kilkari.repository.SubscriptionPackDataService;
 import org.motechproject.nms.kilkari.service.SubscriptionService;
 import org.motechproject.nms.props.domain.DayOfTheWeek;
@@ -63,6 +65,9 @@ public class TargetFileServiceBundleIT extends BasePaxIT {
     SubscriptionService subscriptionService;
 
     @Inject
+    SubscriptionDataService subscriptionDataService;
+
+    @Inject
     SubscriberDataService subscriberDataService;
 
     @Inject
@@ -90,6 +95,13 @@ public class TargetFileServiceBundleIT extends BasePaxIT {
     SettingsService settingsService;
 
     private void setupDatabase() {
+        for (Subscription subscription: subscriptionDataService.retrieveAll()) {
+            subscription.setStatus(SubscriptionStatus.COMPLETED);
+            subscription.setEndDate(new DateTime().withDate(2011, 8, 1));
+
+            subscriptionDataService.update(subscription);
+        }
+
         subscriptionService.deleteAll();
         subscriberDataService.deleteAll();
         languageLocationDataService.deleteAll();

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/domain/Subscription.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/domain/Subscription.java
@@ -52,6 +52,9 @@ public class Subscription {
     private DateTime startDate;
 
     @Field
+    private DateTime endDate;
+
+    @Field
     private DayOfTheWeek startDayOfTheWeek;
 
     @Field
@@ -90,7 +93,15 @@ public class Subscription {
 
     public SubscriptionStatus getStatus() { return status; }
 
-    public void setStatus(SubscriptionStatus status) { this.status = status; }
+    public void setStatus(SubscriptionStatus status) {
+        this.status = status;
+
+        if (this.status == SubscriptionStatus.DEACTIVATED || this.status == SubscriptionStatus.COMPLETED) {
+            setEndDate(new DateTime());
+        } else {
+            setEndDate(null);
+        }
+    }
 
     public SubscriptionOrigin getOrigin() { return origin; }
 
@@ -101,6 +112,14 @@ public class Subscription {
     public void setStartDate(DateTime startDate) {
         this.startDate = startDate;
         this.startDayOfTheWeek = DayOfTheWeek.fromInt(startDate.getDayOfWeek());
+    }
+
+    public DateTime getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(DateTime endDate) {
+        this.endDate = endDate;
     }
 
     public DayOfTheWeek getStartDayOfTheWeek() {
@@ -230,6 +249,7 @@ public class Subscription {
                 ", status=" + status +
                 ", origin=" + origin +
                 ", startDate=" + startDate +
+                ", endDate=" + endDate +
                 '}';
     }
 }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/SubscriberService.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/SubscriberService.java
@@ -1,5 +1,7 @@
 package org.motechproject.nms.kilkari.service;
 
+import org.motechproject.mds.annotations.InstanceLifecycleListener;
+import org.motechproject.mds.domain.InstanceLifecycleListenerType;
 import org.motechproject.nms.kilkari.domain.Subscriber;
 
 /**
@@ -27,4 +29,12 @@ public interface SubscriberService {
      */
     void update(Subscriber subscriber);
 
+    /**
+     * Lifecycle listener that verifies a subscriber can only be deleted if all of their subscriptions have
+     * been closed at least 6 weeks
+     *
+     * @param subscriber
+     */
+    @InstanceLifecycleListener(InstanceLifecycleListenerType.PRE_DELETE)
+    void deleteAllowed(Subscriber subscriber);
 }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/SubscriptionService.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/SubscriptionService.java
@@ -1,6 +1,8 @@
 package org.motechproject.nms.kilkari.service;
 
 import org.joda.time.DateTime;
+import org.motechproject.mds.annotations.InstanceLifecycleListener;
+import org.motechproject.mds.domain.InstanceLifecycleListenerType;
 import org.motechproject.nms.kilkari.domain.DeactivationReason;
 import org.motechproject.nms.kilkari.domain.Subscription;
 import org.motechproject.nms.kilkari.domain.SubscriptionOrigin;
@@ -85,5 +87,14 @@ public interface SubscriptionService {
      * Generate Pregnancy and Child subscription packs and associated messages. To be used only by test code.
      */
     void createSubscriptionPacks();
+
+    /**
+     * Lifecycle listener that verifies a subscription can only be deleted if it is deactivated or completed
+     * and has been in that state for 6 weeks
+     *
+     * @param subscription
+     */
+    @InstanceLifecycleListener(InstanceLifecycleListenerType.PRE_DELETE)
+    void deleteAllowed(Subscription subscription);
 
 }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
@@ -73,4 +73,9 @@ public class SubscriberServiceImpl implements SubscriberService {
         }
     }
 
+    public void deleteAllowed(Subscriber subscriber) {
+        for (Subscription subscription: subscriber.getSubscriptions()) {
+            subscriptionService.deleteAllowed(subscription);
+        }
+    }
 }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriptionServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriptionServiceImpl.java
@@ -1,6 +1,7 @@
 package org.motechproject.nms.kilkari.service.impl;
 
 import org.joda.time.DateTime;
+import org.joda.time.Weeks;
 import org.motechproject.mds.query.QueryParams;
 import org.motechproject.nms.kilkari.domain.DeactivationReason;
 import org.motechproject.nms.kilkari.domain.Subscriber;
@@ -63,6 +64,24 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         }
         if (subscriptionPackDataService.byName("pregnancyPack") == null) {
             createSubscriptionPack("pregnancyPack", SubscriptionPackType.PREGNANCY, PREGNANCY_PACK_WEEKS, 2);
+        }
+    }
+
+    @Override
+    public void deleteAllowed(Subscription subscription) {
+        DateTime now = new DateTime();
+
+        if (subscription.getStatus() != SubscriptionStatus.COMPLETED &&
+                subscription.getStatus() != SubscriptionStatus.DEACTIVATED) {
+            throw new IllegalStateException("Can not delete an open subscription");
+        }
+
+        if (subscription.getEndDate() == null) {
+            throw new IllegalStateException("Subscription in closed state with null end date");
+        }
+
+        if (Math.abs(Weeks.weeksBetween(now, subscription.getEndDate()).getWeeks()) < 6) {
+            throw new IllegalStateException("Subscription must be closed for 6 weeks before deleting");
         }
     }
 
@@ -246,4 +265,6 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         return subscriptionDataService.findByStatusAndDay(SubscriptionStatus.ACTIVE, dayOfTheWeek,
                 new QueryParams(page, pageSize));
     }
+
+
 }

--- a/kilkari/src/test/java/org/motechproject/nms/kilkari/osgi/CsrServiceBundleIT.java
+++ b/kilkari/src/test/java/org/motechproject/nms/kilkari/osgi/CsrServiceBundleIT.java
@@ -106,6 +106,13 @@ public class CsrServiceBundleIT extends BasePaxIT {
 
     @Before
     public void cleanupDatabase() {
+        for (Subscription subscription: subscriptionDataService.retrieveAll()) {
+            subscription.setStatus(SubscriptionStatus.COMPLETED);
+            subscription.setEndDate(new DateTime().withDate(2011, 8, 1));
+
+            subscriptionDataService.update(subscription);
+        }
+
         subscriptionService.deleteAll();
         subscriberDataService.deleteAll();
         languageLocationDataService.deleteAll();

--- a/kilkari/src/test/java/org/motechproject/nms/kilkari/osgi/IntegrationTests.java
+++ b/kilkari/src/test/java/org/motechproject/nms/kilkari/osgi/IntegrationTests.java
@@ -8,7 +8,9 @@ import org.junit.runners.Suite;
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-        SubscriptionServiceBundleIT.class, CsrServiceBundleIT.class
+    SubscriptionServiceBundleIT.class,
+    SubscriberServiceBundleIT.class,
+    CsrServiceBundleIT.class
 })
 public class IntegrationTests {
 }

--- a/kilkari/src/test/java/org/motechproject/nms/kilkari/osgi/SubscriberServiceBundleIT.java
+++ b/kilkari/src/test/java/org/motechproject/nms/kilkari/osgi/SubscriberServiceBundleIT.java
@@ -1,0 +1,190 @@
+package org.motechproject.nms.kilkari.osgi;
+
+import org.joda.time.DateTime;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.motechproject.mds.ex.JdoListenerInvocationException;
+import org.motechproject.nms.kilkari.domain.Subscriber;
+import org.motechproject.nms.kilkari.domain.Subscription;
+import org.motechproject.nms.kilkari.domain.SubscriptionOrigin;
+import org.motechproject.nms.kilkari.domain.SubscriptionPack;
+import org.motechproject.nms.kilkari.domain.SubscriptionStatus;
+import org.motechproject.nms.kilkari.repository.InboxCallDataDataService;
+import org.motechproject.nms.kilkari.repository.InboxCallDetailRecordDataService;
+import org.motechproject.nms.kilkari.repository.SubscriberDataService;
+import org.motechproject.nms.kilkari.repository.SubscriptionDataService;
+import org.motechproject.nms.kilkari.repository.SubscriptionPackDataService;
+import org.motechproject.nms.kilkari.repository.SubscriptionPackMessageDataService;
+import org.motechproject.nms.kilkari.service.SubscriberService;
+import org.motechproject.nms.kilkari.service.SubscriptionService;
+import org.motechproject.nms.region.domain.Circle;
+import org.motechproject.nms.region.domain.District;
+import org.motechproject.nms.region.domain.Language;
+import org.motechproject.nms.region.domain.LanguageLocation;
+import org.motechproject.nms.region.domain.State;
+import org.motechproject.nms.region.repository.CircleDataService;
+import org.motechproject.nms.region.repository.DistrictDataService;
+import org.motechproject.nms.region.repository.LanguageDataService;
+import org.motechproject.nms.region.repository.LanguageLocationDataService;
+import org.motechproject.nms.region.repository.StateDataService;
+import org.motechproject.testing.osgi.BasePaxIT;
+import org.motechproject.testing.osgi.container.MotechNativeTestContainerFactory;
+import org.ops4j.pax.exam.ExamFactory;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerSuite;
+
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Verify that SubscriberService is present & functional.
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerSuite.class)
+@ExamFactory(MotechNativeTestContainerFactory.class)
+public class SubscriberServiceBundleIT extends BasePaxIT {
+    @Inject
+    private SubscriberService subscriberService;
+    @Inject
+    private SubscriptionService subscriptionService;
+    @Inject
+    private SubscriberDataService subscriberDataService;
+    @Inject
+    private SubscriptionPackDataService subscriptionPackDataService;
+    @Inject
+    private SubscriptionPackMessageDataService subscriptionPackMessageDataService;
+    @Inject
+    private SubscriptionDataService subscriptionDataService;
+    @Inject
+    private LanguageDataService languageDataService;
+    @Inject
+    private InboxCallDetailRecordDataService inboxCallDetailRecordDataService;
+    @Inject
+    private InboxCallDataDataService inboxCallDataDataService;
+    @Inject
+    private LanguageLocationDataService languageLocationDataService;
+    @Inject
+    private StateDataService stateDataService;
+    @Inject
+    private DistrictDataService districtDataService;
+    @Inject
+    private CircleDataService circleDataService;
+
+    private LanguageLocation gLanguageLocation;
+    private SubscriptionPack gPack1;
+    private SubscriptionPack gPack2;
+
+    private void setupData() {
+        cleanupData();
+        createLanguageAndSubscriptionPacks();
+
+        Subscriber subscriber2 = subscriberDataService.create(new Subscriber(2000000000L));
+
+        subscriptionService.createSubscription(subscriber2.getCallingNumber(), gLanguageLocation, gPack1,
+                SubscriptionOrigin.IVR);
+        subscriptionService.createSubscription(subscriber2.getCallingNumber(), gLanguageLocation, gPack2,
+                SubscriptionOrigin.IVR);
+    }
+
+    private void createLanguageAndSubscriptionPacks() {
+        District district = new District();
+        district.setName("District 1");
+        district.setRegionalName("District 1");
+        district.setCode(1L);
+
+        District district2 = new District();
+        district2.setName("District 2");
+        district2.setRegionalName("District 2");
+        district2.setCode(2L);
+
+        State state = new State();
+        state.setName("State 1");
+        state.setCode(1L);
+        state.getDistricts().add(district);
+        state.getDistricts().add(district2);
+
+        stateDataService.create(state);
+
+        Language language = new Language("tamil");
+        languageDataService.create(language);
+
+        LanguageLocation languageLocation = new LanguageLocation("10", new Circle("AA"), language, true);
+        languageLocation.getDistrictSet().add(district);
+        languageLocationDataService.create(languageLocation);
+
+        language = new Language("english");
+        languageDataService.create(language);
+
+        languageLocation = new LanguageLocation("99", new Circle("BB"), language, true);
+        languageLocation.getDistrictSet().add(district2);
+        languageLocationDataService.create(languageLocation);
+
+        subscriptionService.createSubscriptionPacks();
+        gPack1 = subscriptionPackDataService.byName("childPack"); // 48 weeks, 1 message per week
+        gPack2 = subscriptionPackDataService.byName("pregnancyPack"); // 72 weeks, 2 messages per week
+    }
+
+    private void cleanupData() {
+        for (Subscription subscription: subscriptionDataService.retrieveAll()) {
+            subscription.setStatus(SubscriptionStatus.COMPLETED);
+            subscription.setEndDate(new DateTime().withDate(2011, 8, 1));
+
+            subscriptionDataService.update(subscription);
+        }
+
+        subscriptionDataService.deleteAll();
+        subscriptionPackDataService.deleteAll();
+        subscriptionPackMessageDataService.deleteAll();
+        subscriberDataService.deleteAll();
+        circleDataService.deleteAll();
+        districtDataService.deleteAll();
+        stateDataService.deleteAll();
+        languageLocationDataService.deleteAll();
+        languageDataService.deleteAll();
+        inboxCallDataDataService.deleteAll();
+        inboxCallDetailRecordDataService.deleteAll();
+    }
+
+    @Test
+    public void testServicePresent() throws Exception {
+        assertNotNull(subscriberService);
+    }
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void testDeleteSubscriberWithOpenSubscription() {
+        setupData();
+
+        Subscriber subscriber = subscriberService.getSubscriber(2000000000L);
+        assertNotNull(subscriber);
+
+        Subscription subscription = subscriber.getSubscriptions().iterator().next();
+        subscription.setStatus(SubscriptionStatus.COMPLETED);
+        subscriptionDataService.update(subscription);
+
+        exception.expect(JdoListenerInvocationException.class);
+        subscriberDataService.delete(subscriber);
+    }
+
+    @Test
+    public void testDeleteSubscriberWithAllClosedSubscriptions() {
+        setupData();
+
+        Subscriber subscriber = subscriberService.getSubscriber(2000000000L);
+        assertNotNull(subscriber);
+
+        for (Subscription subscription: subscriber.getSubscriptions()) {
+            subscription.setStatus(SubscriptionStatus.COMPLETED);
+            subscription.setEndDate(new DateTime().withDate(2011, 8, 1));
+            subscriptionDataService.update(subscription);
+        }
+
+        subscriberDataService.delete(subscriber);
+    }
+}

--- a/kilkari/src/test/java/org/motechproject/nms/kilkari/ut/SubscriptionUnitTest.java
+++ b/kilkari/src/test/java/org/motechproject/nms/kilkari/ut/SubscriptionUnitTest.java
@@ -14,9 +14,12 @@ import org.motechproject.nms.props.domain.DayOfTheWeek;
 import java.util.ArrayList;
 import java.util.List;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 
 public class SubscriptionUnitTest {
     @Test
@@ -62,6 +65,25 @@ public class SubscriptionUnitTest {
         return new SubscriptionPack(name, type, weeks, messagesPerWeek, messages);
     }
 
+    @Test
+    public void verifySetStatusUpdatesEndDate() {
+        Subscription s = new Subscription(
+                new Subscriber(1111111111L),
+                createSubscriptionPack("pack", SubscriptionPackType.CHILD, 10, 1),
+                SubscriptionOrigin.IVR);
+        s.setStatus(SubscriptionStatus.ACTIVE);
+
+        assertNull(s.getEndDate());
+
+        s.setStatus(SubscriptionStatus.COMPLETED);
+        assertNotNull(s.getEndDate());
+
+        s.setStatus(SubscriptionStatus.ACTIVE);
+        assertNull(s.getEndDate());
+
+        s.setStatus(SubscriptionStatus.DEACTIVATED);
+        assertNotNull(s.getEndDate());
+    }
 
     @Test
     public void verifyNextScheduledMessage() {

--- a/props/src/test/java/org/motechproject/nms/props/ut/CallDisconnectReasonUnitTest.java
+++ b/props/src/test/java/org/motechproject/nms/props/ut/CallDisconnectReasonUnitTest.java
@@ -1,4 +1,4 @@
-package org.motechproject.nms.imi.ut;
+package org.motechproject.nms.props.ut;
 
 import org.junit.Test;
 import org.motechproject.nms.props.domain.CallDisconnectReason;

--- a/props/src/test/java/org/motechproject/nms/props/ut/DayOfTheWeekTest.java
+++ b/props/src/test/java/org/motechproject/nms/props/ut/DayOfTheWeekTest.java
@@ -1,4 +1,4 @@
-package org.motechproject.nms.imi.ut;
+package org.motechproject.nms.props.ut;
 
 import org.joda.time.DateTime;
 import org.junit.Test;

--- a/props/src/test/java/org/motechproject/nms/props/ut/FinalCallStatusTest.java
+++ b/props/src/test/java/org/motechproject/nms/props/ut/FinalCallStatusTest.java
@@ -1,4 +1,4 @@
-package org.motechproject.nms.imi.ut;
+package org.motechproject.nms.props.ut;
 
 import org.junit.Test;
 import org.motechproject.nms.props.domain.FinalCallStatus;

--- a/props/src/test/java/org/motechproject/nms/props/ut/RequestIdUnitTest.java
+++ b/props/src/test/java/org/motechproject/nms/props/ut/RequestIdUnitTest.java
@@ -1,4 +1,4 @@
-package org.motechproject.nms.imi.ut;
+package org.motechproject.nms.props.ut;
 
 import org.junit.Test;
 import org.motechproject.nms.props.domain.RequestId;

--- a/props/src/test/java/org/motechproject/nms/props/ut/StatusCodeUnitTest.java
+++ b/props/src/test/java/org/motechproject/nms/props/ut/StatusCodeUnitTest.java
@@ -1,4 +1,4 @@
-package org.motechproject.nms.imi.ut;
+package org.motechproject.nms.props.ut;
 
 
 import org.junit.Test;


### PR DESCRIPTION
Add a pre-delete lifecycle listener that verifies a subscription has been closed at least 6 weeks
 before it can be deleted.