### PR TITLE
Fixes #112 - deactivate pregnancy subscription

### DIFF
--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/domain/DeactivationReason.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/domain/DeactivationReason.java
@@ -5,6 +5,7 @@ package org.motechproject.nms.kilkari.domain;
  */
 public enum DeactivationReason {
     DEACTIVATED_BY_USER,
+    LIVE_BIRTH,
     MISCARRIAGE_OR_ABORTION,
     STILL_BIRTH,
     CHILD_DEATH,

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/domain/MctsBeneficiary.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/domain/MctsBeneficiary.java
@@ -120,4 +120,24 @@ public abstract class MctsBeneficiary {
     public void setVillage(Village village) {
         this.village = village;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MctsBeneficiary that = (MctsBeneficiary) o;
+
+        return !(beneficiaryId != null ? !beneficiaryId.equals(that.beneficiaryId) : that.beneficiaryId != null);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return beneficiaryId != null ? beneficiaryId.hashCode() : 0;
+    }
 }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/SubscriptionService.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/SubscriptionService.java
@@ -65,12 +65,12 @@ public interface SubscriptionService {
     SubscriptionPack getSubscriptionPack(String name);
 
     /**
-     * Returns boolean indicating whether or not the subscriber has an active subscription for the specified pack type
+     * Returns active subscription for the specified pack type if the subscriber has one
      * @param subscriber The subscriber
      * @param type The type of subscription pack
-     * @return True if the subscriber has an active subscription to this pack, false otherwise
+     * @return The subscription if an active one exists, null otherwise
      */
-    boolean subscriberHasActiveSubscription(Subscriber subscriber, SubscriptionPackType type);
+    Subscription getActiveSubscription(Subscriber subscriber, SubscriptionPackType type);
 
     List<SubscriptionPack> getSubscriptionPacks();
 

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriptionServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriptionServiceImpl.java
@@ -256,7 +256,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
 
         if (subscriber.getDateOfBirth() != null && pack.getType() == SubscriptionPackType.CHILD) {
             // DOB (with or without LMP) is present
-            if (subscriberHasActiveSubscription(subscriber, SubscriptionPackType.CHILD))
+            if (getActiveSubscription(subscriber, SubscriptionPackType.CHILD) != null)
             {
                 // reject the subscription if it already exists
                 logRejectedSubscription(subscriber.getCallingNumber(),
@@ -273,7 +273,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         } else if (subscriber.getLastMenstrualPeriod() != null && subscriber.getDateOfBirth() == null &&
                 pack.getType() == SubscriptionPackType.PREGNANCY) {
             // LMP is present and DOB is not
-            if (subscriberHasActiveSubscription(subscriber, SubscriptionPackType.PREGNANCY)) {
+            if (getActiveSubscription(subscriber, SubscriptionPackType.PREGNANCY) != null) {
                 // reject the subscription if it already exists
                 logRejectedSubscription(subscriber.getCallingNumber(),
                         SubscriptionRejectionReason.ALREADY_SUBSCRIBED, SubscriptionPackType.PREGNANCY);
@@ -305,7 +305,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     }
 
     @Override
-    public boolean subscriberHasActiveSubscription(Subscriber subscriber, SubscriptionPackType type) {
+    public Subscription getActiveSubscription(Subscriber subscriber, SubscriptionPackType type) {
         Iterator<Subscription> subscriptionIterator = subscriber.getSubscriptions().iterator();
         Subscription existingSubscription;
 
@@ -315,14 +315,14 @@ public class SubscriptionServiceImpl implements SubscriptionService {
                 if (type == SubscriptionPackType.PREGNANCY &&
                         (existingSubscription.getStatus() == SubscriptionStatus.ACTIVE ||
                          existingSubscription.getStatus() == SubscriptionStatus.PENDING_ACTIVATION)) {
-                    return true;
+                    return existingSubscription;
                 }
                 if (type == SubscriptionPackType.CHILD && existingSubscription.getStatus() == SubscriptionStatus.ACTIVE) {
-                    return true;
+                    return existingSubscription;
                 }
             }
         }
-        return false;
+        return null;
     }
 
     @Override

--- a/testing/src/test/java/org/motechproject/nms/testing/it/kilkari/MctsBeneficiaryImportServiceBundleIT.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/kilkari/MctsBeneficiaryImportServiceBundleIT.java
@@ -25,12 +25,8 @@ import org.motechproject.nms.region.domain.Taluka;
 import org.motechproject.nms.region.domain.Village;
 import org.motechproject.nms.region.repository.CircleDataService;
 import org.motechproject.nms.region.repository.DistrictDataService;
-import org.motechproject.nms.region.repository.HealthBlockDataService;
-import org.motechproject.nms.region.repository.HealthFacilityDataService;
 import org.motechproject.nms.region.repository.LanguageDataService;
 import org.motechproject.nms.region.repository.StateDataService;
-import org.motechproject.nms.region.repository.TalukaDataService;
-import org.motechproject.nms.region.repository.VillageDataService;
 import org.motechproject.nms.testing.it.utils.SubscriptionHelper;
 import org.motechproject.nms.testing.service.TestingService;
 import org.motechproject.testing.osgi.BasePaxIT;
@@ -50,6 +46,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import static org.motechproject.nms.testing.it.utils.RegionHelper.createDistrict;
 import static org.motechproject.nms.testing.it.utils.RegionHelper.createHealthFacilityType;
@@ -251,7 +248,13 @@ public class MctsBeneficiaryImportServiceBundleIT extends BasePaxIT {
         assertEquals(dob.toLocalDate(), subscriber.getDateOfBirth().toLocalDate());
 
         subscriptions = subscriber.getActiveSubscriptions();
-        assertEquals(2, subscriptions.size());
+        Subscription childSubscription = subscriptionService.getActiveSubscription(subscriber, SubscriptionPackType.CHILD);
+        Subscription pregnancySubscription = subscriptionService.getActiveSubscription(subscriber, SubscriptionPackType.PREGNANCY);
+
+        // the pregnancy subscription should have been deactivated
+        assertEquals(1, subscriptions.size());
+        assertNotNull(childSubscription);
+        assertNull(pregnancySubscription);
     }
 
     @Test


### PR DESCRIPTION
Deactivate pregnancy subscription if a new child subscription is created via MCTS import with matching mother ID.