### PR TITLE
Fixes #357 - Update subscription origin to IVR if MCTS subscription exists

### DIFF
--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriptionServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriptionServiceImpl.java
@@ -241,7 +241,14 @@ public class SubscriptionServiceImpl implements SubscriptionService {
             if (existingSubscription.getSubscriptionPack().equals(pack)) {
                 if (existingSubscription.getStatus().equals(SubscriptionStatus.ACTIVE) ||
                         existingSubscription.getStatus().equals(SubscriptionStatus.PENDING_ACTIVATION)) {
+
                     // subscriber already has an active subscription to this pack, don't create a new one
+                    // however if origin of existing subscription is MCTS then we want to update it to IVR
+                    if (existingSubscription.getOrigin() == SubscriptionOrigin.MCTS_IMPORT) {
+                        existingSubscription.setOrigin(SubscriptionOrigin.IVR);
+                        subscriptionDataService.update(existingSubscription);
+                    }
+
                     return null;
                 }
             }

--- a/testing/src/test/java/org/motechproject/nms/testing/it/api/KilkariControllerBundleIT.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/api/KilkariControllerBundleIT.java
@@ -430,6 +430,23 @@ public class KilkariControllerBundleIT extends BasePaxIT {
         assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
     }
 
+    @Test
+    public void testCreateSubscriptionRequestAlreadySubscribedViaMCTS() throws IOException, InterruptedException {
+        Subscriber subscriber = subscriberService.getSubscriber(1000000000L);
+        Subscription subscription = subscriber.getActiveSubscriptions().iterator().next();
+        subscription.setOrigin(SubscriptionOrigin.MCTS_IMPORT);
+        subscriptionDataService.update(subscription);
+
+        String subscriptionId = subscription.getSubscriptionId();
+
+        HttpPost httpPost = createSubscriptionHttpPost(1000000000L, sh.childPack().getName());
+
+        HttpResponse response = SimpleHttpClient.httpRequestAndResponse(httpPost, ADMIN_USERNAME, ADMIN_PASSWORD);
+        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+
+        subscription = subscriptionDataService.findBySubscriptionId(subscriptionId);
+        assertEquals(SubscriptionOrigin.IVR, subscription.getOrigin());
+    }
 
     @Test
     public void testCreateSubscriptionRequestInvalidPack() throws IOException, InterruptedException {


### PR DESCRIPTION
If user calls to subscribe but already has a subscription via MCTS update origin to be IVR