### PR TITLE
Using correct file name for welcome message

### DIFF
--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/domain/SubscriptionPackMessage.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/domain/SubscriptionPackMessage.java
@@ -63,6 +63,6 @@ public class SubscriptionPackMessage {
 
     @Ignore
     public static SubscriptionPackMessage getWelcomeMessage() {
-        return new SubscriptionPackMessage(0, "welcome", "welcome.wav", TWO_MINUTES);
+        return new SubscriptionPackMessage(0, "w1_1", "w1_1.wav", TWO_MINUTES);
     }
 }

--- a/testing/src/test/java/org/motechproject/nms/testing/it/imi/TargetFileServiceBundleIT.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/imi/TargetFileServiceBundleIT.java
@@ -404,7 +404,7 @@ public class TargetFileServiceBundleIT extends BasePaxIT {
         String checksum = ChecksumHelper.checksum(targetFile);
         assertEquals((int)tfn.getRecordsCount(), recordCount);
         assertEquals(tfn.getChecksum(), checksum);
-        assertTrue("welcome.wav".equals(contents.get(0)));
+        assertTrue("w1_1.wav".equals(contents.get(0)));
     }
 
     /*
@@ -442,12 +442,10 @@ public class TargetFileServiceBundleIT extends BasePaxIT {
         String checksum = ChecksumHelper.checksum(targetFile);
         assertEquals((int)tfn.getRecordsCount(), recordCount);
         assertEquals(tfn.getChecksum(), checksum);
-        assertTrue("welcome.wav".equals(contents.get(0)));
+        assertTrue("w1_1.wav".equals(contents.get(0)));
 
     }
     //todo: test success notification is sent to the IVR system
-
-
 
 
     @Test

--- a/testing/src/test/java/org/motechproject/nms/testing/it/kilkari/SubscriptionServiceBundleIT.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/kilkari/SubscriptionServiceBundleIT.java
@@ -612,9 +612,9 @@ public class SubscriptionServiceBundleIT extends BasePaxIT {
 
         Subscription subscription = mctsSubscriber.getSubscriptions().iterator().next();
 
-        // initially, the welcome message should be played
+        // initially, the welcome message should be played (welcome message and week 1 message are the same)
         SubscriptionPackMessage message = subscription.nextScheduledMessage(now);
-        assertEquals("welcome", message.getWeekId());
+        assertEquals("w1_1", message.getWeekId());
 
         subscription.setNeedsWelcomeMessage(false);
         subscriptionDataService.update(subscription);


### PR DESCRIPTION
BBC has clarified for us that the welcome message is the same as the week 1 message (we had previously been using a placeholder of "welcome.wav").