### PR TITLE
Fixes NIP-60 (really)

### DIFF
--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/CsrServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/CsrServiceImpl.java
@@ -301,8 +301,8 @@ public class CsrServiceImpl implements CsrService {
 
     private void resetWelcomeFlagInSubscription(Subscription subscription) {
 
-        if (subscription.getNeedsWelcomeMessage() == true) {
-            subscription.setNeedsWelcomeMessage(false);
+        if (subscription.getNeedsWelcomeMessageViaObd() == true) {
+            subscription.setNeedsWelcomeMessageViaObd(false);
             subscriptionDataService.update(subscription);
         }
     }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/InboxServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/InboxServiceImpl.java
@@ -4,6 +4,7 @@ import org.joda.time.DateTime;
 import org.joda.time.Days;
 import org.motechproject.nms.kilkari.domain.InboxCallDetailRecord;
 import org.motechproject.nms.kilkari.domain.Subscription;
+import org.motechproject.nms.kilkari.domain.SubscriptionOrigin;
 import org.motechproject.nms.kilkari.domain.SubscriptionPack;
 import org.motechproject.nms.kilkari.domain.SubscriptionPackMessage;
 import org.motechproject.nms.kilkari.domain.SubscriptionStatus;
@@ -81,7 +82,18 @@ public class InboxServiceImpl implements InboxService {
             }
         }
 
-        return subscription.getSubscriptionPack().getMessages().get(messageIndex);
+        SubscriptionPackMessage smp = subscription.getSubscriptionPack().getMessages().get(messageIndex);
+
+        if ((subscription.getOrigin() == SubscriptionOrigin.MCTS_IMPORT) &&
+                subscription.getNeedsWelcomeMessage()) {
+            // Subscriber has been subscribed via MCTS and may not know what Kilkari is; play welcome message this week
+            smp.setMessageFileName(SubscriptionPackMessage.getWelcomeMessage().getMessageFileName());
+
+            // TODO: Should we set needs welcome message false here?
+            subscription.setNeedsWelcomeMessage(false);
+        }
+
+        return smp;
     }
 
 }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/InboxServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/InboxServiceImpl.java
@@ -35,9 +35,8 @@ public class InboxServiceImpl implements InboxService {
         return (long) inboxCallDetailRecordDataService.getDetachedField(newRecord, "id");
     }
 
-    @Override
+    @Override //NO CHECKSTYLE CyclomaticComplexity
     public SubscriptionPackMessage getInboxMessage(Subscription subscription) throws NoInboxForSubscriptionException {
-
         if ((subscription.getStartDate() == null) || (subscription.getStatus() == SubscriptionStatus.DEACTIVATED)) {
             // there is no inbox for this subscription, throw
             throw new NoInboxForSubscriptionException(String.format("No inbox exists for subscription %s",
@@ -82,18 +81,15 @@ public class InboxServiceImpl implements InboxService {
             }
         }
 
-        SubscriptionPackMessage smp = subscription.getSubscriptionPack().getMessages().get(messageIndex);
+        SubscriptionPackMessage spm = subscription.getSubscriptionPack().getMessages().get(messageIndex);
 
         if ((subscription.getOrigin() == SubscriptionOrigin.MCTS_IMPORT) &&
-                subscription.getNeedsWelcomeMessage()) {
+                subscription.needsWelcomeMessageViaInbox()) {
             // Subscriber has been subscribed via MCTS and may not know what Kilkari is; play welcome message this week
-            smp.setMessageFileName(SubscriptionPackMessage.getWelcomeMessage().getMessageFileName());
-
-            // TODO: Should we set needs welcome message false here?
-            subscription.setNeedsWelcomeMessage(false);
+            spm.setMessageFileName(SubscriptionPackMessage.getWelcomeMessage().getMessageFileName());
         }
 
-        return smp;
+        return spm;
     }
 
 }

--- a/testing/src/test/java/org/motechproject/nms/testing/it/imi/TargetFileServiceBundleIT.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/imi/TargetFileServiceBundleIT.java
@@ -269,7 +269,7 @@ public class TargetFileServiceBundleIT extends BasePaxIT {
         subscriberDataService.create(subscriber1);
         Subscription subscription = subscriptionService.createSubscription(1111111111L, rh.hindiLanguage(),
                 sh.pregnancyPack(), SubscriptionOrigin.MCTS_IMPORT);
-        subscription.setNeedsWelcomeMessage(false);
+        subscription.setNeedsWelcomeMessageViaObd(false);
         subscriptionDataService.update(subscription);
 
         List<String> contents = new ArrayList<>();
@@ -311,7 +311,7 @@ public class TargetFileServiceBundleIT extends BasePaxIT {
         subscriberDataService.create(subscriber1);
         Subscription subscription = subscriptionService.createSubscription(1111111111L, rh.hindiLanguage(),
                 sh.childPack(), SubscriptionOrigin.MCTS_IMPORT);
-        subscription.setNeedsWelcomeMessage(false);
+        subscription.setNeedsWelcomeMessageViaObd(false);
         subscriptionDataService.update(subscription);
 
         List<String> contents = new ArrayList<>();

--- a/testing/src/test/java/org/motechproject/nms/testing/it/kilkari/CsrServiceBundleIT.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/kilkari/CsrServiceBundleIT.java
@@ -1134,7 +1134,7 @@ public class CsrServiceBundleIT extends BasePaxIT {
 
         List<Subscription> subscriptions = subscriptionDataService.retrieveAll();
         assertEquals(1, subscriptions.size());
-        assertEquals(false,subscriptions.get(0).getNeedsWelcomeMessage());
+        assertEquals(false,subscriptions.get(0).getNeedsWelcomeMessageViaObd());
     }
 
     //todo: verify multiple days' worth of summary record aggregation

--- a/testing/src/test/java/org/motechproject/nms/testing/it/kilkari/InboxServiceBundleIT.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/kilkari/InboxServiceBundleIT.java
@@ -363,8 +363,8 @@ public class InboxServiceBundleIT extends BasePaxIT {
  		subscriber.setDateOfBirth(now.minusDays(4));
  		subscriberService.create(subscriber);
 
- 		Subscription childSubscription = subscriptionService.createSubscription(subscriber.getCallingNumber(), rh.hindiLanguage(), sh.childPack(), 
- 				SubscriptionOrigin.MCTS_IMPORT);
+ 		Subscription childSubscription = subscriptionService.createSubscription(subscriber.getCallingNumber(), rh.hindiLanguage(), sh.childPack(),
+				SubscriptionOrigin.MCTS_IMPORT);
  		assertEquals(1, childSubscription.getSubscriptionPack().getMessagesPerWeek());
  		SubscriptionPackMessage packMessage = inboxService.getInboxMessage(childSubscription);
  		assertEquals("w1_1", packMessage.getWeekId());
@@ -413,5 +413,41 @@ public class InboxServiceBundleIT extends BasePaxIT {
  		assertEquals("w1_1.wav", packMessage.getMessageFileName());
 
  	}
+
+	@Test
+	public void testInboxPlaysWelcomeMessageAfterActivation() throws Exception {
+		DateTime now = DateTime.now();
+
+		// Configuration for second msg of the week
+		Subscriber subscriber = new Subscriber(1000000002L, rh.hindiLanguage());
+		subscriber.setLastMenstrualPeriod(now.minusDays(108));
+		subscriberService.create(subscriber);
+
+		subscriptionService.createSubscription(subscriber.getCallingNumber(), rh.hindiLanguage(),
+				sh.pregnancyPack(), SubscriptionOrigin.MCTS_IMPORT);
+
+		subscriber = subscriberService.getSubscriber(subscriber.getCallingNumber());
+		Set<Subscription> subscriptions = subscriber.getAllSubscriptions();
+		Subscription subscription = subscriptions.iterator().next();
+		SubscriptionPackMessage msg = inboxService.getInboxMessage(subscription);
+
+		// second msg of 3rd week should be in inbox
+		assertEquals(msg.getWeekId(), "w3_2");
+		assertEquals(msg.getMessageFileName(), "w3_2.wav");
+
+		// Configuration for first msg of the week
+		subscriber.setLastMenstrualPeriod(DateTime.now().minusDays(104));
+		subscriberService.update(subscriber);
+
+		subscriber = subscriberService.getSubscriber(subscriber.getCallingNumber());
+		subscriptions = subscriber.getAllSubscriptions();
+		subscription = subscriptions.iterator().next();
+		msg = inboxService.getInboxMessage(subscription);
+
+		// welcome msg should be in inbox
+		assertEquals(msg.getWeekId(), "w1_1");
+		assertEquals(msg.getMessageFileName(), "w1_1.wav");
+
+	}
 
 }

--- a/testing/src/test/java/org/motechproject/nms/testing/it/kilkari/SubscriptionServiceBundleIT.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/kilkari/SubscriptionServiceBundleIT.java
@@ -616,7 +616,7 @@ public class SubscriptionServiceBundleIT extends BasePaxIT {
         SubscriptionPackMessage message = subscription.nextScheduledMessage(now);
         assertEquals("w1_1", message.getWeekId());
 
-        subscription.setNeedsWelcomeMessage(false);
+        subscription.setNeedsWelcomeMessageViaObd(false);
         subscriptionDataService.update(subscription);
 
         message = subscription.nextScheduledMessage(now.plusDays(8)); //one week and a day
@@ -638,7 +638,7 @@ public class SubscriptionServiceBundleIT extends BasePaxIT {
         mctsSubscriber = subscriberDataService.findByCallingNumber(9999911122L);
 
         Subscription subscription = mctsSubscriber.getSubscriptions().iterator().next();
-        subscription.setNeedsWelcomeMessage(false);
+        subscription.setNeedsWelcomeMessageViaObd(false);
         subscriptionDataService.update(subscription);
 
         // should throw IllegalStateException


### PR DESCRIPTION
If the user needs the welcome message, set that as the filename.

@llavoie This feels wrong to me.  First, the ticket is hard to follow.  Once it was decided that the actual issue was something different then the description should be updated.  As far as I can tell this "fixes" it.  Although it seems odd that the user will call and only hear the week 1/welcome message when the actual message is week 5 or something else.  Shouldn't we return two messages, the week 1/welcome and the actual message?