### PR TITLE
Fixes NIP-56

### DIFF
--- a/imi/src/main/java/org/motechproject/nms/imi/service/impl/ImiServiceId.java
+++ b/imi/src/main/java/org/motechproject/nms/imi/service/impl/ImiServiceId.java
@@ -1,0 +1,25 @@
+package org.motechproject.nms.imi.service.impl;
+
+/**
+ * A method for IMI to treat OBD request in different ways
+ * see https://applab.atlassian.net/browse/NIP-56
+ */
+public enum ImiServiceId {
+    CHECK_DND,
+    DO_NOT_CHECK_DND;
+
+    public static final String CHECK_DND_STRINGVAL = "S1";
+    public static final String NO_NOT_CHECK_DND_STRINGVAL = "S2";
+
+    public static String imiValue(ImiServiceId serviceId) {
+        if (serviceId == CHECK_DND) {
+            return CHECK_DND_STRINGVAL;
+        }
+
+        if (serviceId == DO_NOT_CHECK_DND) {
+            return NO_NOT_CHECK_DND_STRINGVAL;
+        }
+
+        throw new IllegalStateException("Unexpected ImiServiceId value");
+    }
+}

--- a/imi/src/main/resources/imi.properties
+++ b/imi/src/main/resources/imi.properties
@@ -33,12 +33,6 @@ imi.notification_retry_count=3
 #initial delay (in seconds) of the notification exponential retry (how we try to talk to IMI again after failure)
 imi.initial_retry_delay=1
 
-#4.4.1 Target File Format
-#field #2 ServiceId - Unique Id provided by IMI for a particular service
-#todo: should this be stored in the database?
-#todo: https://github.com/motech-implementations/mim/pull/266#discussion_r30760092
-imi.target_file_imi_service_id=imiserviceid
-
 #maximum number of errors allowed in a CDR file after which all errors are ignored so as to not overwhelm the
 #audit table & the tomcat log file
 imi.max_cdr_error_count=100

--- a/testing/src/test/java/org/motechproject/nms/testing/it/imi/TargetFileServiceBundleIT.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/imi/TargetFileServiceBundleIT.java
@@ -1,6 +1,7 @@
 package org.motechproject.nms.testing.it.imi;
 
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -23,6 +24,8 @@ import org.motechproject.nms.kilkari.repository.SubscriptionPackDataService;
 import org.motechproject.nms.kilkari.service.SubscriberService;
 import org.motechproject.nms.kilkari.service.SubscriptionService;
 import org.motechproject.nms.props.domain.DayOfTheWeek;
+import org.motechproject.nms.imi.service.impl.ImiServiceId;
+import org.motechproject.nms.props.domain.RequestId;
 import org.motechproject.nms.region.repository.CircleDataService;
 import org.motechproject.nms.region.repository.DistrictDataService;
 import org.motechproject.nms.region.repository.LanguageDataService;
@@ -130,8 +133,8 @@ public class TargetFileServiceBundleIT extends BasePaxIT {
         Subscriber subscriber1 = new Subscriber(1111111111L, rh.hindiLanguage(), rh.delhiCircle());
         subscriber1.setLastMenstrualPeriod(DateTime.now().minusDays(90)); // startDate will be today
         subscriberDataService.create(subscriber1);
-        subscriptionService.createSubscription(1111111111L, rh.hindiLanguage(), sh.pregnancyPack(),
-                SubscriptionOrigin.MCTS_IMPORT);
+        Subscription subscription1 = subscriptionService.createSubscription(1111111111L, rh.hindiLanguage(),
+                sh.pregnancyPack(), SubscriptionOrigin.MCTS_IMPORT);
 
         // Should not be picked up because it's been deactivated
         Subscriber subscriber2 = new Subscriber(2222222222L, rh.kannadaLanguage(), rh.karnatakaCircle());
@@ -171,6 +174,20 @@ public class TargetFileServiceBundleIT extends BasePaxIT {
         subscription6.setStatus(SubscriptionStatus.PENDING_ACTIVATION);
         subscriptionDataService.update(subscription6);
 
+        //Set the clock one day back;
+        DateTimeUtils.setCurrentMillisFixed(DateTime.now().minusDays(1).getMillis());
+
+        //Should be picked up because IVR subscriptions all start today + 1 day
+        Subscriber subscriber7 = new Subscriber(7777777777L, rh.kannadaLanguage(), rh.karnatakaCircle());
+        subscriberDataService.create(subscriber7);
+        Subscription subscription7 = subscriptionService.createSubscription(7777777777L, rh.kannadaLanguage(),
+                sh.childPack(), SubscriptionOrigin.IVR);
+
+        //Set the clock back to normal
+        DateTimeUtils.setCurrentMillisSystem();
+
+
+
         // Should not be picked up because it's not for today
         callRetryDataService.create(new CallRetry("11111111-1111-1111-1111-111111111111", 3333333333L,
                 DayOfTheWeek.today().nextDay(), CallStage.RETRY_1, "w1_m1.wav", "w1_1",
@@ -187,22 +204,44 @@ public class TargetFileServiceBundleIT extends BasePaxIT {
         // Should pickup subscription4 and set its status to ACTIVE
         // Should not pickup subscription5 because its start DOW doesn't match today's DOW but should set its status to ACTIVE
         // Should not pickup subscription6 because it's for tomorrow
-        assertEquals(2, (int) tfn.getRecordsCount());
+        // Should pickup subscription7
+        assertEquals(3, (int) tfn.getRecordsCount());
 
         //read the file to get record count
         File targetDir = new File(settingsService.getSettingsFacade().getProperty("imi.local_obd_dir"));
         File targetFile = new File(targetDir, tfn.getFileName());
         int recordCount = 0;
-        boolean header = true;
+        boolean foundSubscription1 = false;
+        boolean foundSubscription4 = false;
+        boolean foundSubscription7 = false;
         try (InputStream is = Files.newInputStream(targetFile.toPath());
              BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
-            while ((reader.readLine()) != null) {
-                if (header) {
-                    header = false;
-                    continue;
+
+            // skip the header
+            reader.readLine();
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String[] fields = line.split(",");
+
+                RequestId requestId = RequestId.fromString(fields[0]);
+                if (requestId.getSubscriptionId().equals(subscription7.getSubscriptionId())) {
+                    foundSubscription7 = true;
+                    assertEquals(ImiServiceId.NO_NOT_CHECK_DND_STRINGVAL, fields[1]);
+                }
+                if (requestId.getSubscriptionId().equals(subscription4.getSubscriptionId())) {
+                    foundSubscription4 = true;
+                }
+                if (requestId.getSubscriptionId().equals(subscription1.getSubscriptionId())) {
+                    foundSubscription1 = true;
+                    assertEquals(ImiServiceId.CHECK_DND_STRINGVAL, fields[1]);
                 }
                 recordCount++;
             }
+
+            assertTrue(foundSubscription1);
+            assertTrue(foundSubscription4);
+            assertTrue(foundSubscription7);
         }
 
         String checksum = ChecksumHelper.checksum(targetFile);


### PR DESCRIPTION
`generateTargetFile` now uses S1 and S2 as `ImiServiceId` field
for MCTS and IVR subscriptions, respectively