### PR TITLE
Fixes NIP-57

### DIFF
--- a/imi/src/main/java/org/motechproject/nms/imi/service/impl/CsvHelper.java
+++ b/imi/src/main/java/org/motechproject/nms/imi/service/impl/CsvHelper.java
@@ -78,8 +78,16 @@ public final class CsvHelper {
 
 
     private static Integer calculateMsgPlayDuration(String msgPlayStartTime, String msgPlayEndTime) {
-        Long start = longFromString("MsgPlayStartTime", msgPlayStartTime);
-        Long end = longFromString("MsgPlayEndTime", msgPlayEndTime);
+        Long start;
+        Long end;
+
+        try {
+            start = longFromString("MsgPlayStartTime", msgPlayStartTime);
+            end = longFromString("MsgPlayEndTime", msgPlayEndTime);
+        } catch (IllegalArgumentException e) {
+            // MsgPlayStart is optional, so if either is missing return the play time as 0
+            return 0;
+        }
 
         if (end < start) {
             throw new IllegalArgumentException("MsgPlayEndTime cannot be before MsgPlayStartTime");


### PR DESCRIPTION
If either MsgPlayTime field is missing return the play duration as 0.  These are optional fields.
