### PR TITLE
137

### DIFF
--- a/flw/pom.xml
+++ b/flw/pom.xml
@@ -19,6 +19,7 @@
     </properties>
 
     <dependencies>
+
         <dependency>
             <groupId>org.motechproject</groupId>
             <artifactId>motech-platform-osgi-extender-fragment</artifactId>
@@ -40,6 +41,12 @@
         <dependency>
             <groupId>org.motechproject.nms</groupId>
             <artifactId>csv</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.motechproject.nms</groupId>
+            <artifactId>tracking</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -107,6 +114,7 @@
                         </Export-Package>
                         <Import-Package>
                             org.motechproject.osgi.web,
+                            org.motechproject.nms.tracking.aspect,
                             org.aopalliance.aop,
                             org.springframework.aop,
                             org.springframework.aop.framework,
@@ -142,6 +150,42 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>aspectj-maven-plugin</artifactId>
+                <version>1.4</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.aspectj</groupId>
+                        <artifactId>aspectjrt</artifactId>
+                        <version>1.7.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.aspectj</groupId>
+                        <artifactId>aspectjtools</artifactId>
+                        <version>1.7.0</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                    <aspectLibraries>
+                        <dependency>
+                            <groupId>org.motechproject.nms</groupId>
+                            <artifactId>tracking</artifactId>
+                        </dependency>
+                    </aspectLibraries>
+                </configuration>
             </plugin>
 
         </plugins>

--- a/flw/src/main/java/org/motechproject/nms/flw/domain/FrontLineWorker.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/domain/FrontLineWorker.java
@@ -3,8 +3,11 @@ package org.motechproject.nms.flw.domain;
 import org.joda.time.DateTime;
 import org.motechproject.mds.annotations.Entity;
 import org.motechproject.mds.annotations.Field;
+import org.motechproject.mds.annotations.InstanceLifecycleListeners;
 import org.motechproject.mds.domain.MdsEntity;
 import org.motechproject.nms.flw.domain.validation.ValidFrontLineWorker;
+import org.motechproject.nms.tracking.annotation.TrackClass;
+import org.motechproject.nms.tracking.annotation.TrackField;
 import org.motechproject.nms.region.domain.District;
 import org.motechproject.nms.region.domain.FullLocation;
 import org.motechproject.nms.region.domain.HealthBlock;
@@ -27,6 +30,8 @@ import javax.validation.constraints.Min;
 @ValidFrontLineWorker
 @Entity(tableName = "nms_front_line_workers")
 @Index(name = "status_invalidationDate_composit_idx", members = { "status", "invalidationDate" })
+@TrackClass
+@InstanceLifecycleListeners
 public class FrontLineWorker extends MdsEntity implements FullLocation {
 
     @Field
@@ -95,6 +100,7 @@ public class FrontLineWorker extends MdsEntity implements FullLocation {
         return flwId;
     }
 
+    @TrackField
     public void setFlwId(String flwId) {
         this.flwId = flwId;
     }
@@ -103,6 +109,7 @@ public class FrontLineWorker extends MdsEntity implements FullLocation {
         return mctsFlwId;
     }
 
+    @TrackField
     public void setMctsFlwId(String mctsFlwId) {
         this.mctsFlwId = mctsFlwId;
     }
@@ -111,6 +118,7 @@ public class FrontLineWorker extends MdsEntity implements FullLocation {
         return contactNumber;
     }
 
+    @TrackField
     public void setContactNumber(Long contactNumber) {
         this.contactNumber = contactNumber;
     }
@@ -119,6 +127,7 @@ public class FrontLineWorker extends MdsEntity implements FullLocation {
         return name;
     }
 
+    @TrackField
     public void setName(String name) {
         this.name = name;
     }
@@ -127,6 +136,7 @@ public class FrontLineWorker extends MdsEntity implements FullLocation {
         return status;
     }
 
+    @TrackField
     public void setStatus(FrontLineWorkerStatus status) {
         this.status = status;
 
@@ -141,6 +151,7 @@ public class FrontLineWorker extends MdsEntity implements FullLocation {
         return invalidationDate;
     }
 
+    @TrackField
     public void setInvalidationDate(DateTime invalidationDate) {
         this.invalidationDate = invalidationDate;
     }
@@ -149,6 +160,7 @@ public class FrontLineWorker extends MdsEntity implements FullLocation {
         return language;
     }
 
+    @TrackField
     public void setLanguage(Language language) {
         this.language = language;
     }
@@ -169,6 +181,7 @@ public class FrontLineWorker extends MdsEntity implements FullLocation {
     }
 
     @Override
+    @TrackField
     public void setDistrict(District district) {
         this.district = district;
     }

--- a/kilkari/pom.xml
+++ b/kilkari/pom.xml
@@ -59,6 +59,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.motechproject.nms</groupId>
+            <artifactId>tracking</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
         </dependency>
@@ -103,6 +109,7 @@
                         </Export-Package>
                         <Import-Package>
                             org.motechproject.osgi.web,
+                            org.motechproject.nms.tracking.aspect,
                             org.aopalliance.aop,
                             org.springframework.aop,
                             org.springframework.aop.framework,
@@ -139,6 +146,42 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>aspectj-maven-plugin</artifactId>
+                <version>1.4</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.aspectj</groupId>
+                        <artifactId>aspectjrt</artifactId>
+                        <version>1.7.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.aspectj</groupId>
+                        <artifactId>aspectjtools</artifactId>
+                        <version>1.7.0</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                    <aspectLibraries>
+                        <dependency>
+                            <groupId>org.motechproject.nms</groupId>
+                            <artifactId>tracking</artifactId>
+                        </dependency>
+                    </aspectLibraries>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/domain/MctsBeneficiary.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/domain/MctsBeneficiary.java
@@ -3,7 +3,6 @@ package org.motechproject.nms.kilkari.domain;
 import org.motechproject.mds.annotations.Entity;
 import org.motechproject.mds.annotations.Field;
 import org.motechproject.mds.domain.MdsEntity;
-import org.motechproject.mds.annotations.InstanceLifecycleListeners;
 import org.motechproject.nms.region.domain.District;
 import org.motechproject.nms.region.domain.FullLocation;
 import org.motechproject.nms.region.domain.HealthBlock;
@@ -25,7 +24,6 @@ import javax.validation.constraints.NotNull;
 @ValidFullLocation
 @Entity(tableName = "nms_mcts_beneficiaries")
 @TrackClass
-@InstanceLifecycleListeners
 public abstract class MctsBeneficiary extends MdsEntity implements FullLocation {
 
     // 18-digit IDs are used for most states but not all, so a strict length constraint cannot be set for this column

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/domain/MctsBeneficiary.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/domain/MctsBeneficiary.java
@@ -3,6 +3,7 @@ package org.motechproject.nms.kilkari.domain;
 import org.motechproject.mds.annotations.Entity;
 import org.motechproject.mds.annotations.Field;
 import org.motechproject.mds.domain.MdsEntity;
+import org.motechproject.mds.annotations.InstanceLifecycleListeners;
 import org.motechproject.nms.region.domain.District;
 import org.motechproject.nms.region.domain.FullLocation;
 import org.motechproject.nms.region.domain.HealthBlock;
@@ -12,6 +13,8 @@ import org.motechproject.nms.region.domain.State;
 import org.motechproject.nms.region.domain.Taluka;
 import org.motechproject.nms.region.domain.Village;
 import org.motechproject.nms.region.domain.validation.ValidFullLocation;
+import org.motechproject.nms.tracking.annotation.TrackClass;
+import org.motechproject.nms.tracking.annotation.TrackField;
 
 import javax.jdo.annotations.Unique;
 import javax.validation.constraints.NotNull;
@@ -21,6 +24,8 @@ import javax.validation.constraints.NotNull;
  */
 @ValidFullLocation
 @Entity(tableName = "nms_mcts_beneficiaries")
+@TrackClass
+@InstanceLifecycleListeners
 public abstract class MctsBeneficiary extends MdsEntity implements FullLocation {
 
     // 18-digit IDs are used for most states but not all, so a strict length constraint cannot be set for this column
@@ -69,6 +74,7 @@ public abstract class MctsBeneficiary extends MdsEntity implements FullLocation 
         return beneficiaryId;
     }
 
+    @TrackField
     public void setBeneficiaryId(String beneficiaryId) {
         this.beneficiaryId = beneficiaryId;
     }
@@ -77,6 +83,7 @@ public abstract class MctsBeneficiary extends MdsEntity implements FullLocation 
         return name;
     }
 
+    @TrackField
     public void setName(String name) {
         this.name = name;
     }
@@ -87,6 +94,7 @@ public abstract class MctsBeneficiary extends MdsEntity implements FullLocation 
     }
 
     @Override
+    @TrackField
     public void setState(State state) {
         this.state = state;
     }
@@ -97,6 +105,7 @@ public abstract class MctsBeneficiary extends MdsEntity implements FullLocation 
     }
 
     @Override
+    @TrackField
     public void setDistrict(District district) {
         this.district = district;
     }
@@ -107,6 +116,7 @@ public abstract class MctsBeneficiary extends MdsEntity implements FullLocation 
     }
 
     @Override
+    @TrackField
     public void setTaluka(Taluka taluka) {
         this.taluka = taluka;
     }
@@ -117,6 +127,7 @@ public abstract class MctsBeneficiary extends MdsEntity implements FullLocation 
     }
 
     @Override
+    @TrackField
     public void setHealthBlock(HealthBlock healthBlock) {
         this.healthBlock = healthBlock;
     }
@@ -127,6 +138,7 @@ public abstract class MctsBeneficiary extends MdsEntity implements FullLocation 
     }
 
     @Override
+    @TrackField
     public void setHealthFacility(HealthFacility primaryHealthCenter) {
         this.primaryHealthCenter = primaryHealthCenter;
     }
@@ -137,6 +149,7 @@ public abstract class MctsBeneficiary extends MdsEntity implements FullLocation 
     }
 
     @Override
+    @TrackField
     public void setHealthSubFacility(HealthSubFacility healthSubFacility) {
         this.healthSubFacility = healthSubFacility;
     }
@@ -147,6 +160,7 @@ public abstract class MctsBeneficiary extends MdsEntity implements FullLocation 
     }
 
     @Override
+    @TrackField
     public void setVillage(Village village) {
         this.village = village;
     }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/domain/MctsChild.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/domain/MctsChild.java
@@ -3,9 +3,14 @@ package org.motechproject.nms.kilkari.domain;
 
 import org.motechproject.mds.annotations.Entity;
 import org.motechproject.mds.annotations.Field;
+import org.motechproject.mds.annotations.InstanceLifecycleListeners;
+import org.motechproject.nms.tracking.annotation.TrackClass;
+import org.motechproject.nms.tracking.annotation.TrackField;
 
 
 @Entity(tableName = "nms_mcts_children")
+@TrackClass
+@InstanceLifecycleListeners
 public class MctsChild extends MctsBeneficiary {
 
     @Field
@@ -24,6 +29,7 @@ public class MctsChild extends MctsBeneficiary {
         return mother;
     }
 
+    @TrackField
     public void setMother(MctsMother mother) {
         this.mother = mother;
     }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/domain/MctsMother.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/domain/MctsMother.java
@@ -4,7 +4,13 @@ import org.joda.time.DateTime;
 import org.motechproject.mds.annotations.Entity;
 import org.motechproject.mds.annotations.Field;
 
+import org.motechproject.mds.annotations.InstanceLifecycleListeners;
+import org.motechproject.nms.tracking.annotation.TrackClass;
+import org.motechproject.nms.tracking.annotation.TrackField;
+
 @Entity(tableName = "nms_mcts_mothers")
+@TrackClass
+@InstanceLifecycleListeners
 public class MctsMother extends MctsBeneficiary {
 
     @Field
@@ -18,6 +24,7 @@ public class MctsMother extends MctsBeneficiary {
         return dateOfBirth;
     }
 
+    @TrackField
     public void setDateOfBirth(DateTime dateOfBirth) {
         this.dateOfBirth = dateOfBirth;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -716,6 +716,7 @@
     </dependencyManagement>
 
     <modules>
+        <module>tracking</module>
         <module>csv</module>
         <module>mobile-academy</module>
         <module>kilkari</module>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -97,6 +97,12 @@
             <artifactId>csv</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.motechproject.nms</groupId>
+            <artifactId>tracking</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <repositories>
@@ -259,12 +265,15 @@
                         <Context-Path>testing</Context-Path>
                         <Export-Package>
                             org.motechproject.nms.testing.service,
+                            org.motechproject.nms.testing.tracking.repository,
+                            org.motechproject.nms.testing.tracking.domain
                         </Export-Package>
                         <Import-Package>
                             org.motechproject.osgi.web,
                             org.motechproject.nms.region.service,
                             org.motechproject.nms.kilkari.service,
                             org.motechproject.nms.csv.service,
+                            org.motechproject.nms.tracking.repository,
                             org.aopalliance.aop,
                             org.springframework.aop,
                             org.springframework.aop.framework,
@@ -301,6 +310,42 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>aspectj-maven-plugin</artifactId>
+                <version>1.4</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.aspectj</groupId>
+                        <artifactId>aspectjrt</artifactId>
+                        <version>1.7.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.aspectj</groupId>
+                        <artifactId>aspectjtools</artifactId>
+                        <version>1.7.0</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <!--<goal>test-compile</goal>-->
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                    <aspectLibraries>
+                        <dependency>
+                            <groupId>org.motechproject.nms</groupId>
+                            <artifactId>tracking</artifactId>
+                        </dependency>
+                    </aspectLibraries>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/testing/src/main/java/org/motechproject/nms/testing/tracking/domain/TrackedEntity.java
+++ b/testing/src/main/java/org/motechproject/nms/testing/tracking/domain/TrackedEntity.java
@@ -1,0 +1,59 @@
+package org.motechproject.nms.testing.tracking.domain;
+
+import org.motechproject.mds.annotations.Entity;
+import org.motechproject.mds.annotations.Field;
+import org.motechproject.mds.annotations.InstanceLifecycleListeners;
+import org.motechproject.nms.tracking.annotation.TrackClass;
+import org.motechproject.nms.tracking.annotation.TrackField;
+
+@Entity
+@TrackClass
+@InstanceLifecycleListeners
+public class TrackedEntity {
+
+    @Field
+    private Long id;
+
+    @Field
+    private Integer integer;
+
+    @Field
+    private String string;
+
+    @Field
+    private TrackedEntity instance;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Integer getInteger() {
+        return integer;
+    }
+
+    public void setInteger(Integer integer) {
+        this.integer = integer;
+    }
+
+    public String getString() {
+        return string;
+    }
+
+    @TrackField
+    public void setString(String string) {
+        this.string = string;
+    }
+
+    public TrackedEntity getInstance() {
+        return instance;
+    }
+
+    @TrackField
+    public void setInstance(TrackedEntity instance) {
+        this.instance = instance;
+    }
+}

--- a/testing/src/main/java/org/motechproject/nms/testing/tracking/repository/TrackedEntityDataService.java
+++ b/testing/src/main/java/org/motechproject/nms/testing/tracking/repository/TrackedEntityDataService.java
@@ -1,0 +1,7 @@
+package org.motechproject.nms.testing.tracking.repository;
+
+import org.motechproject.mds.service.MotechDataService;
+import org.motechproject.nms.testing.tracking.domain.TrackedEntity;
+
+public interface TrackedEntityDataService extends MotechDataService<TrackedEntity> {
+}

--- a/testing/src/main/resources/META-INF/spring/blueprint.xml
+++ b/testing/src/main/resources/META-INF/spring/blueprint.xml
@@ -72,6 +72,10 @@
     <osgi:reference id="43" interface="org.motechproject.nms.csv.repository.CsvAuditRecordDataService" />
     <osgi:reference id="44" interface="org.motechproject.nms.csv.service.CsvAuditService" />
 
+    <osgi:reference id="45" interface="org.motechproject.nms.tracking.repository.ChangeLogDataService" />
+
+    <osgi:reference id="tracking1" interface="org.motechproject.nms.testing.tracking.repository.TrackedEntityDataService" />
+
     <osgi:reference id="transactionManager" interface="org.springframework.transaction.PlatformTransactionManager"/>
     <osgi:reference id="eventRelay" interface="org.motechproject.event.listener.EventRelay"/>
 

--- a/testing/src/test/java/org/motechproject/nms/testing/it/tracking/TrackChangesServiceBundleIT.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/tracking/TrackChangesServiceBundleIT.java
@@ -1,0 +1,123 @@
+package org.motechproject.nms.testing.it.tracking;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.motechproject.nms.testing.tracking.domain.TrackedEntity;
+import org.motechproject.nms.testing.tracking.repository.TrackedEntityDataService;
+import org.motechproject.nms.tracking.domain.ChangeLog;
+import org.motechproject.nms.tracking.repository.ChangeLogDataService;
+import org.motechproject.testing.osgi.BasePaxIT;
+import org.motechproject.testing.osgi.container.MotechNativeTestContainerFactory;
+import org.ops4j.pax.exam.ExamFactory;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerSuite;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+
+import javax.inject.Inject;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerSuite.class)
+@ExamFactory(MotechNativeTestContainerFactory.class)
+public class TrackChangesServiceBundleIT extends BasePaxIT {
+
+    @Inject
+    TrackedEntityDataService trackedEntityDataService;
+
+    @Inject
+    ChangeLogDataService changeLogDataService;
+
+    @Before
+    public void setUp() {
+        for (TrackedEntity trackedEntity : trackedEntityDataService.retrieveAll()) {
+            trackedEntity.setInstance(null);
+            trackedEntityDataService.update(trackedEntity);
+        }
+        trackedEntityDataService.deleteAll();
+        changeLogDataService.deleteAll();
+    }
+
+    @Test
+    public void testChangesTrackedForInstanceCreation() {
+        final TrackedEntity relatedInstance = trackedEntityDataService.create(new TrackedEntity());
+        TrackedEntity trackedInstance = createInstanceInTransaction(42, "hello", relatedInstance);
+
+        List<ChangeLog> changes = changeLogDataService.findByEntityNameAndInstanceId(TrackedEntity.class.getName(), trackedInstance.getId());
+
+        assertEquals(1, changes.size());
+        String change = changes.get(0).getChange();
+        assertFalse(change.contains("integer"));
+        assertTrue(change.contains("string(null, hello)"));
+        assertTrue(change.contains(String.format("instance(null, %d)", relatedInstance.getId())));
+    }
+
+    @Test
+    public void testChangesTrackedForInstanceUpdate() {
+        final TrackedEntity oldRelatedInstance = trackedEntityDataService.create(new TrackedEntity());
+        final TrackedEntity newRelatedInstance = trackedEntityDataService.create(new TrackedEntity());
+        final TrackedEntity trackedInstance = createInstanceInTransaction(42, "hello", oldRelatedInstance);
+        TrackedEntity updatedTrackedInstance = updateInstanceInTransaction(trackedInstance.getId(), 24, "world", newRelatedInstance);
+
+        List<ChangeLog> changes = changeLogDataService.findByEntityNameAndInstanceId(TrackedEntity.class.getName(), updatedTrackedInstance.getId());
+
+        assertEquals(2, changes.size());
+        String change = changes.get(0).getTimestamp().isAfter(changes.get(1).getTimestamp()) ?
+                changes.get(0).getChange() :
+                changes.get(1).getChange();
+        assertFalse(change.contains("integer"));
+        assertTrue(change.contains("string(hello, world)"));
+        assertTrue(change.contains(String.format("instance(%d, %d)", oldRelatedInstance.getId(), newRelatedInstance.getId())));
+    }
+
+    @Test
+    public void testChangesDeletedWithInstanceDeletion() {
+        final TrackedEntity oldRelatedInstance = trackedEntityDataService.create(new TrackedEntity());
+        final TrackedEntity newRelatedInstance = trackedEntityDataService.create(new TrackedEntity());
+        final TrackedEntity trackedInstance = createInstanceInTransaction(42, "hello", oldRelatedInstance);
+        TrackedEntity updatedTrackedInstance = updateInstanceInTransaction(trackedInstance.getId(), 24, "world", newRelatedInstance);
+
+        List<ChangeLog> changes;
+        changes = changeLogDataService.findByEntityNameAndInstanceId(TrackedEntity.class.getName(), updatedTrackedInstance.getId());
+        assertEquals(2, changes.size());
+
+        trackedEntityDataService.delete(updatedTrackedInstance);
+
+        changes = changeLogDataService.findByEntityNameAndInstanceId(TrackedEntity.class.getName(), updatedTrackedInstance.getId());
+        assertTrue(CollectionUtils.isEmpty(changes));
+    }
+
+    private TrackedEntity createInstanceInTransaction(final int integer, final String string, final TrackedEntity instance) {
+        return trackedEntityDataService.doInTransaction(new TransactionCallback<TrackedEntity>() {
+            @Override
+            public TrackedEntity doInTransaction(TransactionStatus transactionStatus) {
+                TrackedEntity trackedInstance = new TrackedEntity();
+                trackedInstance.setInteger(integer); // not tracked
+                trackedInstance.setString(string); // tracked
+                trackedInstance.setInstance(instance); // tracked
+                return trackedEntityDataService.create(trackedInstance);
+            }
+        });
+    }
+
+    private TrackedEntity updateInstanceInTransaction(final Long instanceId, final int integer, final String string, final TrackedEntity instance) {
+        return trackedEntityDataService.doInTransaction(new TransactionCallback<TrackedEntity>() {
+            @Override
+            public TrackedEntity doInTransaction(TransactionStatus transactionStatus) {
+                TrackedEntity updatedTrackedInstance = trackedEntityDataService.findById(instanceId);
+                updatedTrackedInstance.setInteger(integer); // not tracked
+                updatedTrackedInstance.setString(string); // tracked
+                updatedTrackedInstance.setInstance(instance); // tracked
+                return updatedTrackedInstance;
+            }
+        });
+    }
+}

--- a/tracking/pom.xml
+++ b/tracking/pom.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>nms</artifactId>
+        <groupId>org.motechproject.nms</groupId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>tracking</artifactId>
+    <version>0.1-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>Tracking Module</name>
+
+    <properties>
+        <modules.root.dir>${basedir}/..</modules.root.dir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.motechproject</groupId>
+            <artifactId>motech-platform-osgi-extender-fragment</artifactId>
+            <version>${motech.version}</version>
+        </dependency>
+
+        <!-- OSGi IT -->
+        <dependency>
+            <groupId>org.motechproject</groupId>
+            <artifactId>motech-pax-it</artifactId>
+            <version>${motech.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>motech-repo</id>
+            <name>MOTECH Maven Repository</name>
+            <url>http://nexus.motechproject.org/content/repositories/public</url>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.5</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Blueprint-Enabled>true</Blueprint-Enabled>
+                        <Resource-Path>tracking/resources</Resource-Path>
+                        <Context-Path>tracking</Context-Path>
+                        <Export-Package>
+                            org.motechproject.nms.tracking.annotation;version=${project.version},
+                            org.motechproject.nms.tracking.aspect;version=${project.version},
+                            org.motechproject.nms.tracking.domain;version=${project.version},
+                            org.motechproject.nms.tracking.exception;version=${project.version},
+                            org.motechproject.nms.tracking.repository;version=${project.version},
+                            org.motechproject.nms.tracking.service;version=${project.version},
+                            org.motechproject.nms.tracking.utils;version=${project.version}
+                        </Export-Package>
+                        <Import-Package>
+                            *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <id>copy-bundles</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${user.home}/.motech/bundles</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>target</directory>
+                                    <includes>
+                                        <include>*.jar</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>aspectj-maven-plugin</artifactId>
+                <version>1.4</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.aspectj</groupId>
+                        <artifactId>aspectjrt</artifactId>
+                        <version>1.7.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.aspectj</groupId>
+                        <artifactId>aspectjtools</artifactId>
+                        <version>1.7.0</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tracking/src/main/java/org/motechproject/nms/tracking/annotation/TrackClass.java
+++ b/tracking/src/main/java/org/motechproject/nms/tracking/annotation/TrackClass.java
@@ -1,0 +1,11 @@
+package org.motechproject.nms.tracking.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TrackClass {
+}

--- a/tracking/src/main/java/org/motechproject/nms/tracking/annotation/TrackField.java
+++ b/tracking/src/main/java/org/motechproject/nms/tracking/annotation/TrackField.java
@@ -1,0 +1,11 @@
+package org.motechproject.nms.tracking.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TrackField {
+}

--- a/tracking/src/main/java/org/motechproject/nms/tracking/aspect/TrackChangesAspect.java
+++ b/tracking/src/main/java/org/motechproject/nms/tracking/aspect/TrackChangesAspect.java
@@ -35,7 +35,18 @@ public class TrackChangesAspect {
 
     @After("staticinitialization(@org.motechproject.nms.tracking.annotation.TrackClass *)")
     public void registerJdoLifecycleListeners(JoinPoint.StaticPart staticPart) {
-        trackChangesService.registerLifecycleListeners(staticPart.getSignature().getDeclaringType());
+        if (null != trackChangesService) {
+            try {
+                trackChangesService.registerLifecycleListeners(staticPart.getSignature().getDeclaringType());
+            } catch (Exception e) {
+                // log and rethrow static block exceptions
+                LOGGER.error("Failed to register change listeners", e);
+                throw e;
+            }
+        } else {
+            LOGGER.warn("The %s service is missing. This aspect either failed to initialize as a bean " +
+                    "or is used outside the application context", TrackChangesService.class.getSimpleName());
+        }
     }
 
     @Before("execution(* set*(*)) && @annotation(org.motechproject.nms.tracking.annotation.TrackField)")

--- a/tracking/src/main/java/org/motechproject/nms/tracking/aspect/TrackChangesAspect.java
+++ b/tracking/src/main/java/org/motechproject/nms/tracking/aspect/TrackChangesAspect.java
@@ -1,0 +1,113 @@
+package org.motechproject.nms.tracking.aspect;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.DeclareMixin;
+import org.motechproject.mds.util.MemberUtil;
+import org.motechproject.mds.util.PropertyUtil;
+import org.motechproject.nms.tracking.annotation.TrackClass;
+import org.motechproject.nms.tracking.exception.TrackChangesException;
+import org.motechproject.nms.tracking.service.TrackChangesService;
+import org.motechproject.nms.tracking.utils.Change;
+import org.motechproject.nms.tracking.utils.TrackChanges;
+import org.motechproject.nms.tracking.utils.TrackChangesImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+import java.util.Objects;
+
+@Aspect
+public class TrackChangesAspect {
+
+    public static final Logger LOGGER = LoggerFactory.getLogger(TrackChangesAspect.class);
+
+    private TrackChangesService trackChangesService;
+
+    @DeclareMixin("(@org.motechproject.nms.tracking.annotation.TrackClass *)")
+    public static TrackChanges implementTrackChanges() {
+        return new TrackChangesImpl();
+    }
+
+    @After("staticinitialization(@org.motechproject.nms.tracking.annotation.TrackClass *)")
+    public void registerJdoLifecycleListeners(JoinPoint.StaticPart staticPart) {
+        trackChangesService.registerLifecycleListeners(staticPart.getSignature().getDeclaringType());
+    }
+
+    @Before("execution(* set*(*)) && @annotation(org.motechproject.nms.tracking.annotation.TrackField)")
+    public void before(JoinPoint joinPoint) {
+        Object target = joinPoint.getTarget();
+        if (target instanceof TrackChanges) {
+            try {
+                trackChange(joinPoint, target);
+            } catch (TrackChangesException e) {
+                LOGGER.error("Unable to track field changes", e);
+            }
+        } else {
+            LOGGER.warn("Tracked field should be in a class annotated with {}", TrackClass.class.getName());
+        }
+    }
+
+    private void trackChange(JoinPoint joinPoint, Object target) throws TrackChangesException {
+        String propertyName = getPropertyName(joinPoint);
+        Map<String, Change> changes = ((TrackChanges) target).changes();
+        Change change = changes.get(propertyName);
+        if (change == null) {
+            trackNewChange(joinPoint, propertyName, changes);
+        } else {
+            trackExistingChange(joinPoint, propertyName, changes, change);
+        }
+    }
+
+    private void trackNewChange(JoinPoint joinPoint, String propertyName, Map<String, Change> changes)
+            throws TrackChangesException {
+        Object oldValue = getOldValue(joinPoint.getTarget(), propertyName);
+        Object newValue = getNewValue(joinPoint);
+        if (!Objects.equals(oldValue, newValue)) {
+            Change change = new Change(oldValue, newValue);
+            changes.put(propertyName, change);
+        }
+    }
+
+    private void trackExistingChange(JoinPoint joinPoint, String propertyName, Map<String, Change> changes, Change change)
+            throws TrackChangesException {
+        Object oldValue = change.getOldValue();
+        Object newValue = getNewValue(joinPoint);
+        if (!Objects.equals(oldValue, newValue)) {
+            change.setNewValue(newValue);
+        } else {
+            changes.remove(propertyName);
+        }
+    }
+
+    private Object getOldValue(Object target, String propertyName) throws TrackChangesException {
+        try {
+            return PropertyUtil.getProperty(target, propertyName);
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            throw new TrackChangesException("Unable to retrieve old value", e);
+        }
+    }
+
+    private String getPropertyName(JoinPoint joinPoint) {
+        String setterName = joinPoint.getSignature().getName();
+        return MemberUtil.getFieldNameFromGetterSetterName(setterName);
+    }
+
+    private Object getNewValue(JoinPoint joinPoint) throws TrackChangesException {
+        if (joinPoint.getArgs().length == 1) {
+            return joinPoint.getArgs()[0];
+        } else {
+            throw new TrackChangesException("Unable to retrieve new value");
+        }
+    }
+
+    @Autowired
+    public void setTrackChangesService(TrackChangesService trackChangesService) {
+        this.trackChangesService = trackChangesService;
+    }
+
+}

--- a/tracking/src/main/java/org/motechproject/nms/tracking/domain/ChangeLog.java
+++ b/tracking/src/main/java/org/motechproject/nms/tracking/domain/ChangeLog.java
@@ -1,0 +1,63 @@
+package org.motechproject.nms.tracking.domain;
+
+import org.joda.time.DateTime;
+import org.motechproject.mds.annotations.Entity;
+import org.motechproject.mds.annotations.Field;
+
+@Entity
+public class ChangeLog {
+
+    @Field(required = true)
+    private String entityName;
+
+    @Field(required = true)
+    private Long instanceId;
+
+    @Field(required = true)
+    private DateTime timestamp;
+
+    @Field(required = true)
+    private String change;
+
+    public ChangeLog() {
+    }
+
+    public ChangeLog(String entityName, Long instanceId, DateTime timestamp, String change) {
+        this.entityName = entityName;
+        this.instanceId = instanceId;
+        this.timestamp = timestamp;
+        this.change = change;
+    }
+
+    public String getEntityName() {
+        return entityName;
+    }
+
+    public void setEntityName(String entityName) {
+        this.entityName = entityName;
+    }
+
+    public Long getInstanceId() {
+        return instanceId;
+    }
+
+    public void setInstanceId(Long instanceId) {
+        this.instanceId = instanceId;
+    }
+
+    public DateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(DateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getChange() {
+        return change;
+    }
+
+    public void setChange(String change) {
+        this.change = change;
+    }
+}

--- a/tracking/src/main/java/org/motechproject/nms/tracking/exception/TrackChangesException.java
+++ b/tracking/src/main/java/org/motechproject/nms/tracking/exception/TrackChangesException.java
@@ -1,0 +1,14 @@
+package org.motechproject.nms.tracking.exception;
+
+public class TrackChangesException extends Exception {
+
+    private static final long serialVersionUID = -6662426955871119037L;
+
+    public TrackChangesException(String message) {
+        super(message);
+    }
+
+    public TrackChangesException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/tracking/src/main/java/org/motechproject/nms/tracking/repository/ChangeLogDataService.java
+++ b/tracking/src/main/java/org/motechproject/nms/tracking/repository/ChangeLogDataService.java
@@ -1,0 +1,16 @@
+package org.motechproject.nms.tracking.repository;
+
+import org.motechproject.mds.annotations.Lookup;
+import org.motechproject.mds.annotations.LookupField;
+import org.motechproject.mds.service.MotechDataService;
+import org.motechproject.nms.tracking.domain.ChangeLog;
+
+import java.util.List;
+
+public interface ChangeLogDataService extends MotechDataService<ChangeLog> {
+
+    @Lookup
+    List<ChangeLog> findByEntityNameAndInstanceId(
+            @LookupField(name = "entityName") String entityName,
+            @LookupField(name = "instanceId") Long instanceId);
+}

--- a/tracking/src/main/java/org/motechproject/nms/tracking/service/TrackChangesService.java
+++ b/tracking/src/main/java/org/motechproject/nms/tracking/service/TrackChangesService.java
@@ -1,0 +1,10 @@
+package org.motechproject.nms.tracking.service;
+
+public interface TrackChangesService {
+
+    void registerLifecycleListeners(Class<?> entityClass);
+
+    void preStore(Object trackChanges);
+
+    void preDelete(Object trackChanges);
+}

--- a/tracking/src/main/java/org/motechproject/nms/tracking/service/impl/TrackChangesServiceImpl.java
+++ b/tracking/src/main/java/org/motechproject/nms/tracking/service/impl/TrackChangesServiceImpl.java
@@ -1,0 +1,167 @@
+package org.motechproject.nms.tracking.service.impl;
+
+import org.joda.time.DateTime;
+import org.motechproject.mds.domain.InstanceLifecycleListenerType;
+import org.motechproject.mds.listener.MotechLifecycleListener;
+import org.motechproject.mds.service.EntityService;
+import org.motechproject.mds.service.JdoListenerRegistryService;
+import org.motechproject.mds.util.Constants;
+import org.motechproject.mds.util.PropertyUtil;
+import org.motechproject.nms.tracking.domain.ChangeLog;
+import org.motechproject.nms.tracking.exception.TrackChangesException;
+import org.motechproject.nms.tracking.repository.ChangeLogDataService;
+import org.motechproject.nms.tracking.service.TrackChangesService;
+import org.motechproject.nms.tracking.utils.Change;
+import org.motechproject.nms.tracking.utils.TrackChanges;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+public class TrackChangesServiceImpl implements TrackChangesService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TrackChangesServiceImpl.class);
+    public static final String PRE_STORE = "preStore";
+    public static final String PRE_DELETE = "preDelete";
+    public static final String EMPTY_PACKAGE = "";
+
+    private JdoListenerRegistryService jdoListenerRegistryService;
+    private EntityService entityService;
+    private ChangeLogDataService changeLogDataService;
+
+    private Set<String> trackedClasses = new HashSet<>();
+
+    @Override
+    public void registerLifecycleListeners(Class<?> clazz) {
+        if (TrackChanges.class.isAssignableFrom(clazz)) {
+            String className = clazz.getName();
+            if (!trackedClasses.contains(className)) {
+                MotechLifecycleListener preStoreListener = createListener(className, PRE_STORE, InstanceLifecycleListenerType.PRE_STORE);
+                MotechLifecycleListener preDeleteListener = createListener(className, PRE_DELETE, InstanceLifecycleListenerType.PRE_DELETE);
+                jdoListenerRegistryService.registerListener(preStoreListener);
+                jdoListenerRegistryService.registerListener(preDeleteListener);
+                trackedClasses.add(className);
+            }
+        } else {
+            LOGGER.warn("Tracked class should implement the {} interface", TrackChanges.class.getName());
+        }
+    }
+
+    @Override
+    public void preStore(Object target) {
+        if (target instanceof TrackChanges && isEntityInstance(target)) {
+            try {
+                storeChangeLog(target);
+            } catch (TrackChangesException e) {
+                LOGGER.error("Unable to store change log", e);
+            }
+        } else {
+            LOGGER.error("Unable to track changes of " + target.getClass());
+        }
+    }
+
+    @Override
+    public void preDelete(Object target) {
+        if (target instanceof TrackChanges && isEntityInstance(target)) {
+            try {
+                deleteChangeLogs(target);
+            } catch (TrackChangesException e) {
+                LOGGER.error("Unable to delete change logs");
+            }
+        } else {
+            LOGGER.error("Unable to track changes of " + target.getClass());
+        }
+    }
+
+    private void storeChangeLog(Object target) throws TrackChangesException {
+        Map<String, Change> changes = ((TrackChanges) target).changes();
+        if (!changes.isEmpty()) {
+            String entityName = getEntityName(target);
+            Long instanceId = getInstanceId(target);
+            String change = getChange(changes);
+            ChangeLog changeLog = new ChangeLog(entityName, instanceId, DateTime.now(), change);
+            changeLogDataService.create(changeLog);
+        }
+    }
+
+    private void deleteChangeLogs(Object target) throws TrackChangesException {
+        String entityName = getEntityName(target);
+        Long instanceId = getInstanceId(target);
+        List<ChangeLog> changeLogs = changeLogDataService.findByEntityNameAndInstanceId(entityName, instanceId);
+        for (ChangeLog changeLog : changeLogs) {
+            changeLogDataService.delete(changeLog);
+        }
+    }
+
+    private String getEntityName(Object target) {
+        return target.getClass().getName();
+    }
+
+    private Long getInstanceId(Object target) throws TrackChangesException {
+        try {
+            return (Long) PropertyUtil.getProperty(target, Constants.Util.ID_FIELD_NAME);
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException | ClassCastException e) {
+            throw new TrackChangesException("Unable to retrieve instance id", e);
+        }
+    }
+
+    private String getChange(Map<String, Change> changes) throws TrackChangesException {
+        StringBuilder builder = new StringBuilder();
+        for (Iterator<Map.Entry<String, Change>> iterator = changes.entrySet().iterator(); iterator.hasNext(); ) {
+            Map.Entry<String, Change> changeEntry = iterator.next();
+            String propertyName = changeEntry.getKey();
+            Change change = changeEntry.getValue();
+            builder.append(propertyName)
+                    .append("(")
+                    .append(formatPropertyValue(change.getOldValue()))
+                    .append(", ")
+                    .append(formatPropertyValue(change.getNewValue()))
+                    .append(")");
+            if (iterator.hasNext()) {
+                builder.append(",");
+            }
+        }
+        return builder.toString();
+    }
+
+    private String formatPropertyValue(Object value) throws TrackChangesException {
+        if (isEntityInstance(value)) {
+            return String.valueOf(getInstanceId(value));
+        } else {
+            return String.valueOf(value);
+        }
+    }
+
+    private boolean isEntityInstance(Object object) {
+        return object != null && entityService.getEntityByClassName(object.getClass().getName()) != null;
+    }
+
+    private MotechLifecycleListener createListener(String className, String serviceMethod, InstanceLifecycleListenerType listenerType) {
+        return new MotechLifecycleListener(TrackChangesServiceImpl.class, serviceMethod, className,
+                EMPTY_PACKAGE, new InstanceLifecycleListenerType[] {listenerType}, Collections.singletonList(className));
+    }
+
+    @Autowired
+    public void setJdoListenerRegistryService(JdoListenerRegistryService jdoListenerRegistryService) {
+        this.jdoListenerRegistryService = jdoListenerRegistryService;
+    }
+
+    @Autowired
+    public void setEntityService(EntityService entityService) {
+        this.entityService = entityService;
+    }
+
+    @Autowired
+    public void setChangeLogDataService(ChangeLogDataService changeLogDataService) {
+        this.changeLogDataService = changeLogDataService;
+    }
+}

--- a/tracking/src/main/java/org/motechproject/nms/tracking/utils/Change.java
+++ b/tracking/src/main/java/org/motechproject/nms/tracking/utils/Change.java
@@ -1,0 +1,31 @@
+package org.motechproject.nms.tracking.utils;
+
+public class Change {
+
+    private Object oldValue;
+    private Object newValue;
+
+    public Change() {
+    }
+
+    public Change(Object oldValue, Object newValue) {
+        this.oldValue = oldValue;
+        this.newValue = newValue;
+    }
+
+    public Object getOldValue() {
+        return oldValue;
+    }
+
+    public void setOldValue(Object oldValue) {
+        this.oldValue = oldValue;
+    }
+
+    public Object getNewValue() {
+        return newValue;
+    }
+
+    public void setNewValue(Object newValue) {
+        this.newValue = newValue;
+    }
+}

--- a/tracking/src/main/java/org/motechproject/nms/tracking/utils/TrackChanges.java
+++ b/tracking/src/main/java/org/motechproject/nms/tracking/utils/TrackChanges.java
@@ -1,0 +1,9 @@
+package org.motechproject.nms.tracking.utils;
+
+import java.util.Map;
+
+public interface TrackChanges {
+
+    Map<String, Change> changes();
+
+}

--- a/tracking/src/main/java/org/motechproject/nms/tracking/utils/TrackChangesImpl.java
+++ b/tracking/src/main/java/org/motechproject/nms/tracking/utils/TrackChangesImpl.java
@@ -1,0 +1,17 @@
+package org.motechproject.nms.tracking.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TrackChangesImpl implements TrackChanges {
+
+    private Map<String, Change> changes;
+
+    @Override
+    public Map<String, Change> changes() {
+        if (null == changes) {
+            changes = new HashMap<>();
+        }
+        return changes;
+    }
+}

--- a/tracking/src/main/resources/META-INF/motech/applicationContext.xml
+++ b/tracking/src/main/resources/META-INF/motech/applicationContext.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+    <context:annotation-config />
+    <context:component-scan base-package="org.motechproject.nms.tracking" />
+
+    <bean id="trackChangesAspect" class="org.motechproject.nms.tracking.aspect.TrackChangesAspect" factory-method="aspectOf"/>
+</beans>

--- a/tracking/src/main/resources/META-INF/spring/blueprint.xml
+++ b/tracking/src/main/resources/META-INF/spring/blueprint.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:osgi="http://www.eclipse.org/gemini/blueprint/schema/blueprint"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+        http://www.eclipse.org/gemini/blueprint/schema/blueprint
+        http://www.eclipse.org/gemini/blueprint/schema/blueprint/gemini-blueprint.xsd">
+
+    <import resource="classpath*:META-INF/motech/*.xml" />
+
+    <osgi:service ref="trackChangesServiceImpl"
+                  interface="org.motechproject.nms.tracking.service.impl.TrackChangesServiceImpl"/>
+
+    <osgi:reference id="changeLogDataService"
+                    interface="org.motechproject.nms.tracking.repository.ChangeLogDataService"/>
+
+    <osgi:reference id="entityService" interface="org.motechproject.mds.service.EntityService"/>
+
+    <osgi:reference id="jdoListenerRegistryService" interface="org.motechproject.mds.service.JdoListenerRegistryService"/>
+
+</beans>


### PR DESCRIPTION
Needs to wait for http://review.motechproject.org/#/c/5398/ to be merged.

The changes tracking feature works only if the setter method is invoked on the instance that is attached to the PM. It may be the case only for updates. The object must be first retrieved from the data service and then modified via setters - all within a transaction.
Because of this limitation, changes tracking for updates made via MDS UI doesn't work at the moment.