### PR TITLE
Fixes NIP-65

### DIFF
--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
@@ -115,7 +115,9 @@ public class SubscriberServiceImpl implements SubscriberService {
 
             if (subscription.getSubscriptionPack().getType() == SubscriptionPackType.PREGNANCY) {
 
-                subscriptionService.updateStartDate(subscription, subscriber.getLastMenstrualPeriod());
+                if (subscriber.getLastMenstrualPeriod() != null) { // Subscribers via IVR will not have LMP
+                    subscriptionService.updateStartDate(subscription, subscriber.getLastMenstrualPeriod());
+                }
 
             } else if (subscription.getSubscriptionPack().getType() == SubscriptionPackType.CHILD) {
 


### PR DESCRIPTION
Subscribers via IVR will not have an LMP date.  So we check if one exists before attempting
to update the start date.