### PR TITLE
Fixes NIP-72

### DIFF
--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/domain/Subscription.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/domain/Subscription.java
@@ -127,10 +127,7 @@ public class Subscription {
     public void setStartDate(DateTime startDate) {
         this.startDate = startDate;
         this.firstMessageDayOfWeek = DayOfTheWeek.fromInt(startDate.getDayOfWeek());
-
-        if (subscriptionPack.getMessagesPerWeek() == 2) {
-            this.secondMessageDayOfWeek = DayOfTheWeek.fromDateTime(startDate.plusDays(4));
-        }
+        this.secondMessageDayOfWeek = DayOfTheWeek.fromDateTime(startDate.plusDays(4));
     }
 
     public DateTime getEndDate() {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/repository/SubscriptionDataService.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/repository/SubscriptionDataService.java
@@ -8,25 +8,12 @@ import org.motechproject.mds.service.MotechDataService;
 import org.motechproject.mds.util.Constants;
 import org.motechproject.nms.kilkari.domain.Subscription;
 import org.motechproject.nms.kilkari.domain.SubscriptionStatus;
-import org.motechproject.nms.props.domain.DayOfTheWeek;
 
 import java.util.List;
 
 public interface SubscriptionDataService extends MotechDataService<Subscription> {
     @Lookup
     Subscription findBySubscriptionId(@LookupField(name = "subscriptionId") String subscriptionId);
-
-    @Lookup
-    List<Subscription> findByStatusAndFirstMessageDayOfWeek(
-            @LookupField(name = "status") SubscriptionStatus status,
-            @LookupField(name = "firstMessageDayOfWeek") DayOfTheWeek startDayOfTheWeek,
-            QueryParams queryParams);
-
-    @Lookup
-    List<Subscription> findByStatusAndSecondMessageDayOfWeek(
-            @LookupField(name = "status") SubscriptionStatus status,
-            @LookupField(name = "secondMessageDayOfWeek") DayOfTheWeek startDayOfTheWeek,
-            QueryParams queryParams);
 
     @Lookup
     List<Subscription> findByStatus(@LookupField(name = "status")SubscriptionStatus status);

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/SubscriptionService.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/SubscriptionService.java
@@ -10,6 +10,7 @@ import org.motechproject.nms.kilkari.domain.Subscription;
 import org.motechproject.nms.kilkari.domain.SubscriptionOrigin;
 import org.motechproject.nms.kilkari.domain.SubscriptionPack;
 import org.motechproject.nms.kilkari.domain.SubscriptionPackType;
+import org.motechproject.nms.kilkari.domain.SubscriptionStatus;
 import org.motechproject.nms.props.domain.DayOfTheWeek;
 import org.motechproject.nms.region.domain.Circle;
 import org.motechproject.nms.region.domain.Language;
@@ -118,6 +119,36 @@ public interface SubscriptionService {
      * @return The list of subscriptions due for a message
      */
     List<Subscription> findActiveSubscriptionsForDay(DayOfTheWeek dayOfTheWeek, int page, int pageSize);
+
+    /**
+     * Get the list of subscriptions in a specific subscription pack, in the given status with a first message
+     * to be sent on the given day.
+     * @param status
+     * @param firstMessageDayOfWeek
+     * @param subscriptionPack
+     * @param page
+     * @param pageSize
+     * @return The list of subscriptions
+     */
+    List<Subscription> findByStatusAndFirstMessageDayOfWeekAndPack(SubscriptionStatus status,
+                                                                   DayOfTheWeek firstMessageDayOfWeek,
+                                                                   SubscriptionPack subscriptionPack,
+                                                                   int page, int pageSize);
+
+    /**
+     * Get the list of subscriptions in a specific subscription pack, in a given status with a second message
+     * to be sent on the given day.
+     * @param status
+     * @param secondMessageDayOfWeek
+     * @param subscriptionPack
+     * @param page
+     * @param pageSize
+     * @return The list of subscriptions
+     */
+    List<Subscription> findByStatusAndSecondMessageDayOfWeekAndPack(SubscriptionStatus status,
+                                                                    DayOfTheWeek secondMessageDayOfWeek,
+                                                                    SubscriptionPack subscriptionPack,
+                                                                    int page, int pageSize);
 
     /**
      * Get the list of pending subscriptions that starts after the specified date.


### PR DESCRIPTION
When we create a subscription we now set the first and second message date.  When we load
subscriptions at target generation time we decide if we should load only the first message day or first and second message day.