### PR TITLE
For NIP-82

### DIFF
--- a/api/src/main/java/org/motechproject/nms/api/web/CallDetailsController.java
+++ b/api/src/main/java/org/motechproject/nms/api/web/CallDetailsController.java
@@ -12,6 +12,7 @@ import org.motechproject.nms.flw.domain.FrontLineWorkerStatus;
 import org.motechproject.nms.flw.service.CallContentService;
 import org.motechproject.nms.flw.service.CallDetailRecordService;
 import org.motechproject.nms.flw.service.FrontLineWorkerService;
+import org.motechproject.nms.props.domain.FinalCallStatus;
 import org.motechproject.nms.props.domain.Service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -136,7 +137,7 @@ public class CallDetailsController extends BaseController {
         cdr.setCallEndTime(new DateTime(callDetailRecordRequest.getCallEndTime() * MILLISECONDS_PER_SECOND));
         cdr.setCallDurationInPulses(callDetailRecordRequest.getCallDurationInPulses());
         cdr.setEndOfUsagePromptCounter(callDetailRecordRequest.getEndOfUsagePromptCounter());
-        cdr.setCallStatus(callDetailRecordRequest.getCallStatus());
+        cdr.setFinalCallStatus(FinalCallStatus.fromInt(callDetailRecordRequest.getCallStatus()));
         cdr.setCallDisconnectReason(callDetailRecordRequest.getCallDisconnectReason());
 
         if (service == Service.MOBILE_KUNJI) {

--- a/flw/src/main/java/org/motechproject/nms/flw/domain/CallDetailRecord.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/domain/CallDetailRecord.java
@@ -5,7 +5,6 @@ import org.joda.time.DateTime;
 import org.motechproject.mds.annotations.Cascade;
 import org.motechproject.mds.annotations.Entity;
 import org.motechproject.mds.annotations.Field;
-import org.motechproject.mds.annotations.Ignore;
 import org.motechproject.nms.props.domain.CallDisconnectReason;
 import org.motechproject.nms.props.domain.FinalCallStatus;
 import org.motechproject.nms.props.domain.Service;
@@ -174,12 +173,6 @@ public class CallDetailRecord {
 
     public void setFinalCallStatus(FinalCallStatus finalCallStatus) {
         this.finalCallStatus = finalCallStatus;
-    }
-
-    @Ignore
-    public void setCallStatus(int i) {
-
-        this.finalCallStatus = FinalCallStatus.fromInt(i);
     }
 
     public CallDisconnectReason getCallDisconnectReason() {

--- a/flw/src/main/java/org/motechproject/nms/flw/domain/CallDetailRecord.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/domain/CallDetailRecord.java
@@ -5,6 +5,7 @@ import org.joda.time.DateTime;
 import org.motechproject.mds.annotations.Cascade;
 import org.motechproject.mds.annotations.Entity;
 import org.motechproject.mds.annotations.Field;
+import org.motechproject.mds.annotations.Ignore;
 import org.motechproject.nms.props.domain.CallDisconnectReason;
 import org.motechproject.nms.props.domain.FinalCallStatus;
 import org.motechproject.nms.props.domain.Service;
@@ -175,6 +176,7 @@ public class CallDetailRecord {
         this.finalCallStatus = finalCallStatus;
     }
 
+    @Ignore
     public void setCallStatus(int i) {
 
         this.finalCallStatus = FinalCallStatus.fromInt(i);


### PR DESCRIPTION
There was confusion since we have callStatus and finalCallStatus in the database.  I don't remember why we have finalCallStatus, but rather then risk breaking something else I'm just preventing MDS from generating a column for callStatus since we don't have any value we will store there.