### PR TITLE
Fixes NMS-236

### DIFF
--- a/flw/src/main/java/org/motechproject/nms/flw/domain/FrontLineWorker.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/domain/FrontLineWorker.java
@@ -41,7 +41,7 @@ public class FrontLineWorker extends MdsEntity implements FullLocation {
     @Field
     private String mctsFlwId;
 
-    @Field(required = true)
+    @Field()
     @Unique
     @Min(value = 1000000000L, message = "contactNumber must be 10 digits")
     @Max(value = 9999999999L, message = "contactNumber must be 10 digits")
@@ -138,6 +138,7 @@ public class FrontLineWorker extends MdsEntity implements FullLocation {
 
         if (this.status == FrontLineWorkerStatus.INVALID) {
             setInvalidationDate(new DateTime());
+            setContactNumber(null);
         } else {
             setInvalidationDate(null);
         }
@@ -243,7 +244,7 @@ public class FrontLineWorker extends MdsEntity implements FullLocation {
         if (!this.getId().equals(that.getId())) {
             return false;
         }
-        if (!contactNumber.equals(that.contactNumber)) {
+        if (contactNumber != null ? !contactNumber.equals(that.contactNumber) : that.contactNumber != null) {
             return false;
         }
         if (name != null ? !name.equals(that.name) : that.name != null) {

--- a/flw/src/main/java/org/motechproject/nms/flw/domain/validation/FrontLineWorkerValidator.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/domain/validation/FrontLineWorkerValidator.java
@@ -19,8 +19,27 @@ public class FrontLineWorkerValidator implements ConstraintValidator<ValidFrontL
             return true;
         }
 
+        // An active FLW must have a state and district
         if (flw.getStatus() == FrontLineWorkerStatus.ACTIVE &&
                 (flw.getState() == null || flw.getDistrict() == null)) {
+            return false;
+        }
+
+        // Contact Number must be set unless the status is invalid
+        if (flw.getContactNumber() == null && flw.getStatus() != FrontLineWorkerStatus.INVALID) {
+            constraintValidatorContext.disableDefaultConstraintViolation();
+            constraintValidatorContext.buildConstraintViolationWithTemplate(
+                    String.format("Contact Number can not be null for FLW with status %s", flw.getStatus()))
+                            .addConstraintViolation();
+            return false;
+        }
+
+        // invalid FLWs can't have a contact number
+        if (flw.getStatus() == FrontLineWorkerStatus.INVALID && flw.getContactNumber() != null) {
+            constraintValidatorContext.disableDefaultConstraintViolation();
+            constraintValidatorContext.buildConstraintViolationWithTemplate(
+                    String.format("Invalid FLWs can not have a contact number set.", flw.getStatus()))
+                    .addConstraintViolation();
             return false;
         }
 

--- a/flw/src/main/java/org/motechproject/nms/flw/service/FrontLineWorkerService.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/service/FrontLineWorkerService.java
@@ -23,6 +23,8 @@ public interface FrontLineWorkerService {
 
     FrontLineWorker getByMctsFlwIdAndState(String mctsFlwId, State state);
 
+    FrontLineWorker getById(Long id);
+
     List<FrontLineWorker> getRecords();
 
     void update(FrontLineWorker record);

--- a/flw/src/main/java/org/motechproject/nms/flw/service/impl/FrontLineWorkerServiceImpl.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/service/impl/FrontLineWorkerServiceImpl.java
@@ -200,6 +200,11 @@ public class FrontLineWorkerServiceImpl implements FrontLineWorkerService {
     }
 
     @Override
+    public FrontLineWorker getById(Long id) {
+        return frontLineWorkerDataService.findById(id);
+    }
+
+    @Override
     public FrontLineWorker getByContactNumber(Long contactNumber) {
         return frontLineWorkerDataService.findByContactNumber(contactNumber);
     }
@@ -218,14 +223,15 @@ public class FrontLineWorkerServiceImpl implements FrontLineWorkerService {
     @Transactional
     public void update(FrontLineWorker record) {
 
-        FrontLineWorker retrievedFlw = frontLineWorkerDataService.findByContactNumber(record.getContactNumber());
-        FrontLineWorkerStatus oldStatus = retrievedFlw.getStatus();
-
         if (record.getStatus() == FrontLineWorkerStatus.INVALID) {
             // if the caller sets the status to INVALID, that takes precedence over any other status change
             frontLineWorkerDataService.update(record);
             return;
         }
+
+        FrontLineWorker retrievedFlw = frontLineWorkerDataService.findByContactNumber(record.getContactNumber());
+        FrontLineWorkerStatus oldStatus = retrievedFlw.getStatus();
+
         if (oldStatus == FrontLineWorkerStatus.ANONYMOUS) {
             // if the FLW was ANONYMOUS and the required fields get added, update her status to ACTIVE
 

--- a/testing/src/test/java/org/motechproject/nms/testing/it/flw/FrontLineWorkerImportServiceBundleIT.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/flw/FrontLineWorkerImportServiceBundleIT.java
@@ -372,10 +372,10 @@ public class FrontLineWorkerImportServiceBundleIT extends BasePaxIT {
         frontLineWorkerImportService.importData(reader);
     }
 
-    private void assertFLW(FrontLineWorker flw, String mctsFlwId, long contactNumber, String name, String districtName, String languageLocationCode) {
+    private void assertFLW(FrontLineWorker flw, String mctsFlwId, Long contactNumber, String name, String districtName, String languageLocationCode) {
         assertNotNull(flw);
         assertEquals(mctsFlwId, flw.getMctsFlwId());
-        assertEquals(contactNumber, (long) flw.getContactNumber());
+        assertEquals(contactNumber, null != flw.getContactNumber() ? (long) flw.getContactNumber() : null);
         assertEquals(name, flw.getName());
         assertEquals(districtName, null != flw.getDistrict() ? flw.getDistrict().getName() : null);
         assertEquals(languageLocationCode, null != flw.getLanguage() ? flw.getLanguage().getCode() : null);
@@ -465,7 +465,7 @@ public class FrontLineWorkerImportServiceBundleIT extends BasePaxIT {
         frontLineWorkerService.update(flw);
         frontLineWorkerService.delete(flw);
 
-        assertFLW(flw, "#0", 1234567890L, "Test MSISDN", "District 12", language1.getCode());
+        assertFLW(flw, "#0", null, "Test MSISDN", "District 12", language1.getCode());
 
         List<CsvAuditRecord> auditRecords = csvAuditRecordDataService.retrieveAll();
         assertNotNull(auditRecords);

--- a/testing/src/test/java/org/motechproject/nms/testing/it/flw/FrontLineWorkerServiceBundleIT.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/flw/FrontLineWorkerServiceBundleIT.java
@@ -1,17 +1,5 @@
 package org.motechproject.nms.testing.it.flw;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.inject.Inject;
-
 import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
@@ -47,6 +35,17 @@ import org.ops4j.pax.exam.ExamFactory;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerSuite;
+
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -238,7 +237,7 @@ public class FrontLineWorkerServiceBundleIT extends BasePaxIT {
 
         flw.setStatus(FrontLineWorkerStatus.INVALID);
         frontLineWorkerService.update(flw);
-        flw = frontLineWorkerService.getByContactNumber(2111111111L);
+        flw = frontLineWorkerService.getById(flw.getId());
         assertEquals(FrontLineWorkerStatus.INVALID, flw.getStatus());
     }
 
@@ -266,7 +265,7 @@ public class FrontLineWorkerServiceBundleIT extends BasePaxIT {
         flw.setStatus(FrontLineWorkerStatus.INVALID);
         frontLineWorkerService.update(flw);
 
-        flw = frontLineWorkerService.getByContactNumber(2111111111L);
+        flw = frontLineWorkerService.getById(flw.getId());
         assertEquals(FrontLineWorkerStatus.INVALID, flw.getStatus());
 
         exception.expect(JdoListenerInvocationException.class);
@@ -283,7 +282,7 @@ public class FrontLineWorkerServiceBundleIT extends BasePaxIT {
         flw.setInvalidationDate(new DateTime().withDate(2011, 8, 1));
         frontLineWorkerService.update(flw);
 
-        flw = frontLineWorkerService.getByContactNumber(2111111111L);
+        flw = frontLineWorkerService.getById(flw.getId());
         assertEquals(FrontLineWorkerStatus.INVALID, flw.getStatus());
 
         frontLineWorkerService.delete(flw);
@@ -318,6 +317,7 @@ public class FrontLineWorkerServiceBundleIT extends BasePaxIT {
         settingsFacade.setProperty(WEEKS_TO_KEEP_INVALID_FLWS, "1000");
 
         flw = new FrontLineWorker("Test Worker", 2111111111L);
+        flw.setFlwId("FlwId");
         frontLineWorkerService.add(flw);
         flw = frontLineWorkerService.getByContactNumber(2111111111L);
         flw.setStatus(FrontLineWorkerStatus.INVALID);
@@ -330,7 +330,7 @@ public class FrontLineWorkerServiceBundleIT extends BasePaxIT {
         Thread.sleep(10000);
 
         // assert flW not deleted
-        flw = frontLineWorkerService.getByContactNumber(2111111111L);
+        flw = frontLineWorkerService.getByFlwId("FlwId");
         assertNotNull(flw);
     }
 


### PR DESCRIPTION
When a user is marked as INVALID we now null out their contact number.  The non-null
constraint in the database has been removed but a class level validator has been added that
enforces a contact number when the status is not INVALID and that contact number is null when
status is INVALID.

Since the INVALID FLW has no contact number there will be no conflict if a user with that number calls MA/MK.

All other information is retained in the record.