### PR TITLE
Static LMP & DOB options for test MCTS data

### DIFF
--- a/performance/data/data.py
+++ b/performance/data/data.py
@@ -63,6 +63,8 @@ if __name__ == '__main__':
     parser.add_argument("--debug", help="debug mode, even more verbose", action="store_true")
     parser.add_argument("--mctsmoms", help="number of MCTS mothers", type=int, default=0)
     parser.add_argument("--mctskids", help="number of MCTS children", type=int, default=0)
+    parser.add_argument("--lmp", help="static LMP", action="store_true")
+    parser.add_argument("--dob", help="static DOB", action="store_true")
     args = parser.parse_args()
 
     if args.verbose:
@@ -91,10 +93,12 @@ if __name__ == '__main__':
     # Create MCTS mothers file?
     #
     if args.mctsmoms > 0:
-        exec_http_get("{}/module/testing/createMctsMoms".format(args.server), {'count': args.mctsmoms})
+        params = {'count': args.mctsmoms, 'lmp': args.lmp > 0}
+        exec_http_get("{}/module/testing/createMctsMoms".format(args.server), params)
 
     #
     # Create MCTS children file?
     #
     if args.mctskids > 0:
-        exec_http_get("{}/module/testing/createMctsKids".format(args.server), {'count': args.mctskids})
+        params = {'count': args.mctskids, 'dob': args.dob > 0}
+        exec_http_get("{}/module/testing/createMctsKids".format(args.server), params)

--- a/testing/src/main/java/org/motechproject/nms/testing/service/TestingService.java
+++ b/testing/src/main/java/org/motechproject/nms/testing/service/TestingService.java
@@ -11,7 +11,7 @@ public interface TestingService {
 
     void createSubscriptionPacks();
 
-    String createMctsMoms(int count) throws IOException;
+    String createMctsMoms(int count, boolean staticLMP) throws IOException;
 
-    String createMctsKids(int count) throws IOException;
+    String createMctsKids(int count, boolean staticDOB) throws IOException;
 }

--- a/testing/src/main/java/org/motechproject/nms/testing/service/impl/MctsHelper.java
+++ b/testing/src/main/java/org/motechproject/nms/testing/service/impl/MctsHelper.java
@@ -187,12 +187,22 @@ public class MctsHelper {
     }
 
 
+    private DateTime staticLmpDate() {
+        return new DateTime().minusDays(MIN_LMP_DAYS);
+    }
+
+
     private DateTime randomMomBirthDate() {
         DateTime today = new DateTime();
         int year = today.getYear() - randomInt(MIN_MOM_AGE, MAX_MOM_AGE);
         int day = randomInt(1, isLeapYear(year) ? 365 : 364);
 
         return new DateTime().withYear(year).withDayOfYear(day);
+    }
+
+
+    private DateTime staticKidBirthDate() {
+        return new DateTime();
     }
 
 
@@ -241,7 +251,7 @@ public class MctsHelper {
     }
 
 
-    public String oneMctsMom() {
+    public String oneMctsMom(boolean staticLMP) {
 
         Long stateId = randomStateId();
         Long districtId = randomDistrictId(stateId);
@@ -253,7 +263,7 @@ public class MctsHelper {
         String name = randomName();
         Long msisdn = randomMsisdn();
         DateTime birthDate = randomMomBirthDate();
-        DateTime lmpdate = randomLmpDate();
+        DateTime lmpdate = staticLMP ? staticLmpDate() : randomLmpDate();
         StringBuilder sb = new StringBuilder();
 
         //StateID
@@ -393,7 +403,7 @@ public class MctsHelper {
     }
 
 
-    public String oneMctsKid() {
+    public String oneMctsKid(boolean staticDOB) {
 
         Long stateId = randomStateId();
         Long districtId = randomDistrictId(stateId);
@@ -402,7 +412,7 @@ public class MctsHelper {
         Long idNo = randomIdNo();
         String name = randomName();
         Long msisdn = randomMsisdn();
-        DateTime birthDate = randomKidBirthDate();
+        DateTime birthDate = staticDOB ? staticKidBirthDate() : randomKidBirthDate();
 
         StringBuilder sb = new StringBuilder();
         
@@ -527,7 +537,7 @@ public class MctsHelper {
     }
 
 
-    private String createMctsRecipient(boolean mom, int count) throws IOException {
+    private String createMctsRecipient(boolean mom, int count, boolean staticStart) throws IOException {
 
         Timer timer = mom ? new Timer("mom", "moms") :  new Timer("kid", "kids");
         File file = findNewFileName(mom);
@@ -536,7 +546,7 @@ public class MctsHelper {
         writer.newLine();
         for (int i = 0; i < count; i++) {
 
-            writer.write(mom ? oneMctsMom() : oneMctsKid());
+            writer.write(mom ? oneMctsMom(staticStart) : oneMctsKid(staticStart));
             writer.newLine();
 
             if (i > 0 && i % PROGRESS_INTERVAL == 0) {
@@ -558,16 +568,16 @@ public class MctsHelper {
     }
 
 
-    public String createMoms(int count) throws IOException { //NOPMD NcssMethodCount
+    public String createMoms(int count, boolean staticLMP) throws IOException { //NOPMD NcssMethodCount
 
-        LOGGER.debug("createMoms(count={})", count);
-        return createMctsRecipient(true, count);
+        LOGGER.debug("createMoms(count={}, staticLMP={})", count, staticLMP);
+        return createMctsRecipient(true, count, staticLMP);
     }
 
 
-    public String createKids(int count) throws IOException { //NOPMD NcssMethodCount
+    public String createKids(int count, boolean staticDOB) throws IOException { //NOPMD NcssMethodCount
 
-        LOGGER.debug("createKidss(count={})", count);
-        return createMctsRecipient(false, count);
+        LOGGER.debug("createKidss(count={}, staticDOB={})", count, staticDOB);
+        return createMctsRecipient(false, count, staticDOB);
     }
 }

--- a/testing/src/main/java/org/motechproject/nms/testing/service/impl/TestingServiceImpl.java
+++ b/testing/src/main/java/org/motechproject/nms/testing/service/impl/TestingServiceImpl.java
@@ -355,32 +355,30 @@ public class TestingServiceImpl implements TestingService {
     }
 
 
-
-
     @Override
-    public String createMctsMoms(int count) throws IOException {
+    public String createMctsMoms(int count, boolean staticLMP) throws IOException {
 
-        LOGGER.debug("createMctsMoms(count={})", count);
+        LOGGER.debug("createMctsMoms(count={}, lmp={})", count, staticLMP);
 
         if (!Boolean.parseBoolean(settingsFacade.getProperty(TESTING_ENVIRONMENT))) {
             throw new IllegalStateException(TESTING_SERVICE_FORBIDDEN);
         }
 
         MctsHelper mctsHelper = createMctsHelper();
-        return mctsHelper.createMoms(count);
+        return mctsHelper.createMoms(count, staticLMP);
     }
 
 
     @Override
-    public String createMctsKids(int count) throws IOException {
+    public String createMctsKids(int count, boolean staticDOB) throws IOException {
 
-        LOGGER.debug("createMctsKids(count={})", count);
+        LOGGER.debug("createMctsKids(count={}, dob={})", count, staticDOB);
 
         if (!Boolean.parseBoolean(settingsFacade.getProperty(TESTING_ENVIRONMENT))) {
             throw new IllegalStateException(TESTING_SERVICE_FORBIDDEN);
         }
 
         MctsHelper mctsHelper = createMctsHelper();
-        return mctsHelper.createKids(count);
+        return mctsHelper.createKids(count, staticDOB);
     }
 }

--- a/testing/src/main/java/org/motechproject/nms/testing/web/TestingController.java
+++ b/testing/src/main/java/org/motechproject/nms/testing/web/TestingController.java
@@ -62,15 +62,21 @@ public class TestingController {
 
     @RequestMapping(value = "/createMctsMoms")
     @ResponseBody
-    public String createMctsMoms(@RequestParam(required = true) int count) throws IOException {
-        return testingService.createMctsMoms(count);
+    public String createMctsMoms(
+            @RequestParam(required = true) int count,
+            @RequestParam(required = true) boolean lmp)
+            throws IOException {
+        return testingService.createMctsMoms(count, lmp);
     }
 
 
     @RequestMapping(value = "/createMctsKids")
     @ResponseBody
-    public String createMctsKids(@RequestParam(required = true) int count) throws IOException {
-        return testingService.createMctsKids(count);
+    public String createMctsKids(
+            @RequestParam(required = true) int count,
+            @RequestParam(required = true) boolean dob)
+            throws IOException {
+        return testingService.createMctsKids(count, dob);
     }
 
 

--- a/testing/src/test/java/org/motechproject/nms/testing/it/testing/BundleIT.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/testing/BundleIT.java
@@ -94,7 +94,7 @@ public class BundleIT extends BasePaxIT {
         getLogger().debug("createLocationData: {}", timer.time());
 
         timer = new Timer("mom", "moms");
-        String file = testingService.createMctsMoms(TEST_COUNT).split("\t")[0];
+        String file = testingService.createMctsMoms(TEST_COUNT, false).split("\t")[0];
         getLogger().debug("Created {}", timer.frequency(TEST_COUNT));
 
         timer.reset();
@@ -102,7 +102,7 @@ public class BundleIT extends BasePaxIT {
         getLogger().debug("Imported {}", timer.frequency(TEST_COUNT));
 
         timer = new Timer("kid", "kids");
-        file = testingService.createMctsKids(TEST_COUNT).split("\t")[0];
+        file = testingService.createMctsKids(TEST_COUNT, false).split("\t")[0];
         getLogger().debug("Created {}", timer.frequency(TEST_COUNT));
 
         timer.reset();


### PR DESCRIPTION
Calling
```
python ~/src/mim/performance/data/data.py --cleardb --mctsmoms=10000 --lmp
```
with the `--lmp` parameter will generate mothers with a static LMP of 90 days prior to today.
And calling 
```
python ~/src/mim/performance/data/data.py --cleardb --mctskids=10000 --dob
```
with the `--dob` parameter will generate kids with a static DOB of today
