### PR TITLE
Fixes NIP-209, Fixes NIP-208, Fixes #648, Fixes #647

### DIFF
--- a/imi/src/main/java/org/motechproject/nms/imi/service/impl/ExponentialRetrySender.java
+++ b/imi/src/main/java/org/motechproject/nms/imi/service/impl/ExponentialRetrySender.java
@@ -1,10 +1,12 @@
 package org.motechproject.nms.imi.service.impl;
 
 import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContexts;
 import org.apache.http.util.EntityUtils;
@@ -32,6 +34,10 @@ public class ExponentialRetrySender {
     private static final int MAX_NOTIFICATION_RETRY_COUNT_DEFAULT = 3;
     public static final int MILLIS_PER_SEC = 1000;
 
+    private static final String USE_HTTP_TIMEOUT = "imi.use_http_timeout";
+    private static final String HTTP_TIMEOUT_VALUE = "imi.http_timeout_value";
+    private static final int DEFAULT_HTTP_TIMEOUT_VALUE = 30000;
+
     private SettingsFacade settingsFacade;
     private AlertService alertService;
 
@@ -50,7 +56,7 @@ public class ExponentialRetrySender {
      * @param id alert id to use for failure
      * @param name alert name to use for failure
      */
-    public void sendNotificationRequest(HttpPost httpPost, int expectedStatus, String id, String name) {
+    public boolean sendNotificationRequest(final HttpPost httpPost, final int expectedStatus, final String id, final String name) {
         LOGGER.debug("Sending {}", httpPost);
 
         int retryDelay;
@@ -70,6 +76,17 @@ public class ExponentialRetrySender {
 
         String error = "";
 
+        if (shouldUseHttpTimeout()) {
+            int timeout = httpTimeoutValue();
+            RequestConfig requestConfig = RequestConfig.custom()
+                    .setSocketTimeout(timeout)
+                    .setConnectTimeout(timeout)
+                    .setConnectionRequestTimeout(timeout)
+                    .build();
+
+            httpPost.setConfig(requestConfig);
+        }
+
         while (count < maxRetryCount) {
             try {
                 SSLConnectionSocketFactory f = new SSLConnectionSocketFactory(
@@ -78,22 +95,41 @@ public class ExponentialRetrySender {
                                                         null,
                                                         new DefaultHostnameVerifier());
 
-                HttpClient httpClient = HttpClients.custom().setSSLSocketFactory(f).build();
+                CloseableHttpClient httpClient = HttpClients.custom().setSSLSocketFactory(f).build();
 
-                HttpResponse response = httpClient.execute(httpPost);
-                int responseCode = response.getStatusLine().getStatusCode();
-                if (responseCode == expectedStatus) {
-                    return;
-                } else {
-                    error = String.format("Expecting HTTP %d response but received HTTP %d: %s", expectedStatus,
-                            responseCode, EntityUtils.toString(response.getEntity()));
-                    LOGGER.warn(error);
-                    alertService.create(id, name, error, AlertType.MEDIUM, AlertStatus.NEW, 0, null);
+                try {
+
+                    // Create a custom response handler
+                    ResponseHandler<Boolean> responseHandler = new ResponseHandler<Boolean>() {
+
+                        @Override
+                        public Boolean handleResponse(final HttpResponse response) throws IOException {
+                            int responseCode = response.getStatusLine().getStatusCode();
+                            if (responseCode == expectedStatus) {
+                                String msg = String.format("SUCCESS Sending httpPost %s (response %d)", httpPost
+                                        .toString(), responseCode);
+                                LOGGER.debug(msg);
+                                return true;
+                            } else {
+                                String error = String.format("Expecting HTTP %d response but received HTTP %d: %s", expectedStatus,
+                                        responseCode, EntityUtils.toString(response.getEntity()));
+                                LOGGER.warn(error);
+                                alertService.create(id, name, error, AlertType.MEDIUM, AlertStatus.NEW, 0, null);
+                                return false;
+                            }
+                        }
+                    };
+
+                    if (httpClient.execute(httpPost, responseHandler)) {
+                        return true;
+                    }
+                } finally {
+                    httpClient.close();
                 }
             } catch (IOException e) {
-                error = String.format("Unable to send httpPost %s: %s", httpPost.toString(), e.getMessage());
-                LOGGER.warn(error);
-                alertService.create(id, name, error, AlertType.MEDIUM, AlertStatus.NEW, 0, null);
+                    error = String.format("Unable to send httpPost %s: %s", httpPost.toString(), e.getMessage());
+                    LOGGER.warn(error);
+                    alertService.create(id, name, error, AlertType.MEDIUM, AlertStatus.NEW, 0, null);
             }
             count++;
 
@@ -111,6 +147,22 @@ public class ExponentialRetrySender {
         // Retry count exceeded, consider this a critical error
         LOGGER.error(error);
         alertService.create(id, name, error, AlertType.CRITICAL, AlertStatus.NEW, 0, null);
+
+        return false;
     }
 
+    private boolean shouldUseHttpTimeout() {
+        return Boolean.parseBoolean(settingsFacade.getProperty(USE_HTTP_TIMEOUT));
+    }
+
+    private int httpTimeoutValue() {
+        int val;
+        try {
+            val = Integer.parseInt(settingsFacade.getProperty(HTTP_TIMEOUT_VALUE));
+        } catch (NumberFormatException e) {
+            val = DEFAULT_HTTP_TIMEOUT_VALUE;
+        }
+
+        return val;
+    }
 }

--- a/imi/src/main/java/org/motechproject/nms/imi/service/impl/SmsNotificationServiceImpl.java
+++ b/imi/src/main/java/org/motechproject/nms/imi/service/impl/SmsNotificationServiceImpl.java
@@ -75,8 +75,7 @@ public class SmsNotificationServiceImpl implements SmsNotificationService {
         }
 
         ExponentialRetrySender sender = new ExponentialRetrySender(settingsFacade, alertService);
-        sender.sendNotificationRequest(httpPost, HttpStatus.SC_CREATED, ALERT_ID, ALERT_NAME);
-        return true;
+        return sender.sendNotificationRequest(httpPost, HttpStatus.SC_CREATED, ALERT_ID, ALERT_NAME);
     }
 
     private HttpPost prepareSmsRequest(Long callingNumber, String content) {

--- a/imi/src/main/resources/imi.properties
+++ b/imi/src/main/resources/imi.properties
@@ -76,3 +76,9 @@ imi.sms.authentication.key = don'tsaythemagicword
 imi.sms.notification.url = http://localhost/smsmessaging/v1/outbound/nmssenderid/requests
 
 imi.sms.status.callback.url = http://localhost:8080/motech-platform-server/module/api/mobileacademy/smsdeliverystatus
+
+# Should the system set a timeout on http requests
+imi.use_http_timeout=true
+
+# The timeout value in milliseconds
+imi.http_timeout_value=30000


### PR DESCRIPTION
 - Closes the http connection after we get a response back.
 - Logs a success response
 - Adds a config value that allows the turning on of http timeouts
 - Exponential Retry Sender now returns a boolean.  SMS Notification service uses this boolean in the completion record instead of always using true.