### PR TITLE
Duplicate records in obd file fix

### DIFF
--- a/imi/src/main/java/org/motechproject/nms/imi/domain/CallSummaryRecord.java
+++ b/imi/src/main/java/org/motechproject/nms/imi/domain/CallSummaryRecord.java
@@ -203,7 +203,8 @@ public class CallSummaryRecord {
                 circle,
                 timestamp,
                 opt_in_call_eligibility,
-                opt_in_input
+                opt_in_input,
+                serviceId
         );
     }
 }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/dto/CallSummaryRecordDto.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/dto/CallSummaryRecordDto.java
@@ -37,6 +37,8 @@ public class CallSummaryRecordDto implements Serializable {
 
     private String opt_in_input;
 
+    private String serviceId;
+
     public CallSummaryRecordDto() { }
 
     //CHECKSTYLE:OFF
@@ -53,7 +55,7 @@ public class CallSummaryRecordDto implements Serializable {
     }
 
     public CallSummaryRecordDto(String subscriptionId, int statusCode, int finalStatus, String contentFileName,
-                                String weekId, String languageCode, String circleName, String targetFileTimeStamp, Boolean opt_in_call_eligibility, String opt_in_input) {
+                                String weekId, String languageCode, String circleName, String targetFileTimeStamp, Boolean opt_in_call_eligibility, String opt_in_input,String serviceId) {
         this.subscriptionId = subscriptionId;
         this.statusCode = statusCode;
         this.finalStatus = finalStatus;
@@ -64,6 +66,7 @@ public class CallSummaryRecordDto implements Serializable {
         this.targetFileTimeStamp = targetFileTimeStamp;
         this.opt_in_call_eligibility = opt_in_call_eligibility;
         this.opt_in_input = opt_in_input;
+        this.serviceId = serviceId;
     }
 
     // Helper constructor for ITs
@@ -155,6 +158,14 @@ public class CallSummaryRecordDto implements Serializable {
         this.targetFileTimeStamp = targetFileTimeStamp;
     }
 
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public void setServiceId(String serviceId) {
+        this.serviceId = serviceId;
+    }
+
     @Ignore
     public static CallSummaryRecordDto fromParams(Map<String, Object> params) {
         CallSummaryRecordDto csr;
@@ -168,7 +179,8 @@ public class CallSummaryRecordDto implements Serializable {
                 (String) params.get("circleName"),
                 (String) params.get("targetFileTimeStamp"),
                 (Boolean) params.get("opt_in_call_eligibility"),
-                (String) params.get("opt_in_input")
+                (String) params.get("opt_in_input"),
+                (String) params.get("serviceId")
         );
         return csr;
     }
@@ -186,6 +198,7 @@ public class CallSummaryRecordDto implements Serializable {
         params.put("targetFileTimeStamp", csr.targetFileTimeStamp);
         params.put("opt_in_call_eligibility", csr.opt_in_call_eligibility);
         params.put("opt_in_input", csr.opt_in_input);
+        params.put("serviceId", csr.serviceId);
         return params;
     }
 }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/SubscriptionService.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/SubscriptionService.java
@@ -106,6 +106,8 @@ public interface SubscriptionService {
 
     void deleteCallRetry(String subscriptionId);
 
+    void updateCallRetry(String subscriptionId,Long msisdn);
+
     void deleteBlockedMsisdn(Long motherId, Long oldCallingNumber, Long newCallingNumber);
 
     /**

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/CsrServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/CsrServiceImpl.java
@@ -357,9 +357,9 @@ LOGGER.info("this is the data inside: {},{},{]",subscription,existingCallRetry, 
                             LOGGER.info("inside call retry condition");
                             callRetryDataService.delete(callRetry);
                         }
-                    }else if(callRetry == null && !subscription.getFirstMessageDayOfWeek().equals(DayOfTheWeek.getDayOfTheWeekFromTimestamp(csrDto.getTargetFileTimeStamp())) && "1".equals(extractRouteNumber(csrDto.getServiceId()))) {
+                    }else if(callRetry == null && !csrDto.getWeekId().equals("w1_1") && !subscription.getFirstMessageDayOfWeek().equals(DayOfTheWeek.getDayOfTheWeekFromTimestamp(csrDto.getTargetFileTimeStamp())) && "1".equals(extractRouteNumber(csrDto.getServiceId()))) {
                         LOGGER.info("inside fresh call condition after rch update");
-                    }else if(callRetry == null && "2".equals(extractRouteNumber(csrDto.getServiceId()))){
+                    }else if(callRetry == null && !csrDto.getWeekId().equals("w1_1") && "2".equals(extractRouteNumber(csrDto.getServiceId()))){
                         LOGGER.info("inside retry call condition after rch update");
                     }else {
                         LOGGER.info("this is the data2: {}",csrDto.getTargetFileTimeStamp());

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/CsrServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/CsrServiceImpl.java
@@ -36,6 +36,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 import static java.lang.Math.min;
 
@@ -148,7 +149,6 @@ public class CsrServiceImpl implements CsrService {
 
         boolean invalidNr = StatusCode.fromInt(csrDto.getStatusCode()).equals(StatusCode.OBD_FAILED_INVALIDNUMBER);
         if (existingCallRetry == null && SubscriptionStatus.ACTIVE.equals(subscription.getStatus())) {
-            LOGGER.info("inside condition 1");
             // We've never retried this call, let's do it
             callRetryDataService.create(new CallRetry(
                     subscription.getSubscriptionId(),
@@ -200,6 +200,9 @@ public class CsrServiceImpl implements CsrService {
                             )
                     );*/
                     existingCallRetry.setContentFileName("opt_in.wav");
+                    if(!Objects.equals(existingCallRetry.getMsisdn(), subscription.getSubscriber().getCallingNumber())){
+                        existingCallRetry.setMsisdn(subscription.getSubscriber().getCallingNumber());
+                    }
                     callRetryDataService.update(existingCallRetry);
                 } else {
                     completeSubscriptionIfNeeded(subscription, csrDto.getContentFileName());
@@ -235,6 +238,9 @@ public class CsrServiceImpl implements CsrService {
             existingCallRetry.setCallStage(existingCallRetry.getCallStage().nextStage());
             existingCallRetry.setInvalidNumberCount(existingCallRetry.getInvalidNumberCount() == null ? 0 :
                     (existingCallRetry.getInvalidNumberCount() + (invalidNr ? 1 : 0)));
+            if(!Objects.equals(existingCallRetry.getMsisdn(), subscription.getSubscriber().getCallingNumber())){
+                existingCallRetry.setMsisdn(subscription.getSubscriber().getCallingNumber());
+            }
             callRetryDataService.update(existingCallRetry);
         }
 
@@ -287,8 +293,6 @@ public class CsrServiceImpl implements CsrService {
     @MotechListener(subjects = {KilkariConstants.NMS_IMI_KK_PROCESS_CSR_SUBJECT}) //NO CHECKSTYLE Cyclomatic Complexity
     @Transactional
     public void processCallSummaryRecord(MotechEvent event) { //NOPMD NcssMethodCount
-
-        LOGGER.info("inside process call summary record");
         Timer timer = new Timer();
         String whatHappened = "##";
 
@@ -329,11 +333,10 @@ public class CsrServiceImpl implements CsrService {
                             callRetryDataService.delete(callRetry);
                         }
                     }else if(callRetry == null && !csrDto.getWeekId().equals("w1_1") && !subscription.getFirstMessageDayOfWeek().equals(DayOfTheWeek.getDayOfTheWeekFromTimestamp(csrDto.getTargetFileTimeStamp())) && "1".equals(extractRouteNumber(csrDto.getServiceId()))) {
-                        LOGGER.info("inside fresh call condition after rch update");
+                        LOGGER.info("Fresh call condition after rch update");
                     }else if(callRetry == null && !csrDto.getWeekId().equals("w1_1") && "2".equals(extractRouteNumber(csrDto.getServiceId()))){
-                        LOGGER.info("inside retry call condition after rch update");
+                        LOGGER.info("Retry call condition after rch update");
                     }else {
-                        LOGGER.info("this is the data2: {}",csrDto.getTargetFileTimeStamp());
                         if (callRetry == null ||
                                 !csrDto.getTargetFileTimeStamp().equals(callRetry.getTargetFiletimestamp())){
                             doReschedule(subscription, callRetry, csrDto);
@@ -343,13 +346,11 @@ public class CsrServiceImpl implements CsrService {
                     break;
 
                 case REJECTED:
-                    LOGGER.info("inside rejected");
                     handleDndForSubscription(subscription);
                     whatHappened = "RE";
                     break;
 
                 default:
-                    LOGGER.info("inside default");
                     String error = String.format("Invalid FinalCallStatus: %s", csrDto.getFinalStatus());
                     LOGGER.error(error);
                     alertService.create(subscriptionId, KilkariConstants.NMS_IMI_KK_PROCESS_CSR_SUBJECT, error, AlertType.CRITICAL,
@@ -397,16 +398,13 @@ public class CsrServiceImpl implements CsrService {
 
         String subscriptionId = "###INVALID###";
         try {
-            LOGGER.debug("test 20 - WhatsAppOptSMSCsrDto.fromParams");
             WhatsAppOptSMSCsrDto csrDto = WhatsAppOptSMSCsrDto.fromParams(event.getParameters());
             subscriptionId = csrDto.getRequestId();
 //            csrVerifierService.verify(csrDto);
-            LOGGER.debug("test 21 - subscriptionDataService.findBySubscriptionIdAndStatus");
             Subscription subscription = subscriptionDataService.findBySubscriptionIdAndStatus(subscriptionId, SubscriptionStatus.ACTIVE);
             if (subscription == null) {
                 throw new NoSuchSubscriptionException(subscriptionId);
             }
-            LOGGER.debug("test 22 - updateSubscriptionServiceStatusForWhatsAppSMS");
             updateSubscriptionServiceStatusForWhatsAppSMS(subscription, csrDto.getResponse(), (List<Subscription>) event.getParameters().get("subscriptions"));
 
         } catch (NoSuchSubscriptionException e) {
@@ -435,18 +433,15 @@ public class CsrServiceImpl implements CsrService {
 
         String subscriptionId = "###INVALID###";
         try {
-            LOGGER.debug("test 20 - WhatsAppOptCsrDto.fromParams");
             WhatsAppOptCsrDto csrDto = WhatsAppOptCsrDto.fromParams(event.getParameters());
             LOGGER.debug("csrDto: {}", csrDto);
             subscriptionId = csrDto.getExternalId();
 //            csrVerifierService.verify(csrDto);
-            LOGGER.debug("test 21 - subscriptionDataService.findBySubscriptionIdAndStatus");
             Subscription subscription = subscriptionDataService.findBySubscriptionIdAndStatus(subscriptionId, SubscriptionStatus.ACTIVE);
             LOGGER.debug("subscription: {}", subscription);
             if (subscription == null) {
                 throw new NoSuchSubscriptionException(subscriptionId);
             }
-            LOGGER.debug("test 22 - updateSubscriptionServiceStatusForWhatsApp");
             updateSubscriptionServiceStatusForWhatsApp(subscription, csrDto.getMessageStatus(), (List<Subscription>) event.getParameters().get("subscriptions"));
             LOGGER.debug("subscription: {}", subscription);
         } catch (NoSuchSubscriptionException e) {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/CsrServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/CsrServiceImpl.java
@@ -147,8 +147,6 @@ public class CsrServiceImpl implements CsrService {
      private void doReschedule(Subscription subscription, CallRetry existingCallRetry, CallSummaryRecordDto csrDto) {
 
         boolean invalidNr = StatusCode.fromInt(csrDto.getStatusCode()).equals(StatusCode.OBD_FAILED_INVALIDNUMBER);
-LOGGER.info("inside doreshedule method");
-LOGGER.info("this is the data inside: {},{},{]",subscription,existingCallRetry, csrDto);
         if (existingCallRetry == null && SubscriptionStatus.ACTIVE.equals(subscription.getStatus())) {
             LOGGER.info("inside condition 1");
             // We've never retried this call, let's do it
@@ -171,14 +169,12 @@ LOGGER.info("this is the data inside: {},{},{]",subscription,existingCallRetry, 
 
         if ((subscription.getSubscriptionPack().retryCount() == 1) ||
                 (existingCallRetry !=null && existingCallRetry.getCallStage() == CallStage.RETRY_LAST)) {
-            LOGGER.info("inside condition 2");
             // This call should not be retried
 
             // Deactivate subscription for persistent invalid numbers
             // See https://github.com/motech-implementations/mim/issues/169
             if (existingCallRetry != null && existingCallRetry.getInvalidNumberCount() != null &&
                     existingCallRetry.getInvalidNumberCount() == subscription.getSubscriptionPack().retryCount()) {
-                LOGGER.info("inside condition 3");
                 subscription.setStatus(SubscriptionStatus.DEACTIVATED);
                 subscription.setDeactivationReason(DeactivationReason.INVALID_NUMBER);
                 subscriptionDataService.update(subscription);
@@ -186,10 +182,8 @@ LOGGER.info("this is the data inside: {},{},{]",subscription,existingCallRetry, 
             }
             if (existingCallRetry != null && existingCallRetry.isOpt_in_call_eligibility()
                     && existingCallRetry.getCallStage() == CallStage.RETRY_LAST && existingCallRetry.getWeekId().equals("w1_1")) {
-                LOGGER.info("inside condition 4");
                 boolean optInCall = existingCallRetry.getContentFileName().equals("opt_in.wav");
                 if(!optInCall) {
-                    LOGGER.info("inside condition 5");
                     /*callRetryDataService.delete(existingCallRetry);
                     callRetryDataService.create(new CallRetry(
                                     subscription.getSubscriptionId(),
@@ -208,12 +202,8 @@ LOGGER.info("this is the data inside: {},{},{]",subscription,existingCallRetry, 
                     existingCallRetry.setContentFileName("opt_in.wav");
                     callRetryDataService.update(existingCallRetry);
                 } else {
-                    LOGGER.info("inside condition 6");
                     completeSubscriptionIfNeeded(subscription, csrDto.getContentFileName());
                     callRetryDataService.delete(existingCallRetry);
-                    LOGGER.info("subscription is : {}", subscription);
-                    LOGGER.info("csrDto is : {}", csrDto);
-                    LOGGER.info("whatsAppOptSMSDataService is  : {}", whatsAppOptSMSDataService);
                     // write message table logic here
                     whatsAppOptSMSDataService.create(new WhatsAppOptSMS(csrDto.getCircleName(),
                             "SMS_CONTENT",
@@ -230,7 +220,6 @@ LOGGER.info("this is the data inside: {},{},{]",subscription,existingCallRetry, 
                 return;
             }
             if (existingCallRetry != null) {
-                LOGGER.info("inside condition 7");
                 callRetryDataService.delete(existingCallRetry);
             }
 
@@ -243,7 +232,6 @@ LOGGER.info("this is the data inside: {},{},{]",subscription,existingCallRetry, 
 
         // This call should indeed be re-rescheduled
         if (existingCallRetry != null) {
-            LOGGER.info("inside condition 8");
             existingCallRetry.setCallStage(existingCallRetry.getCallStage().nextStage());
             existingCallRetry.setInvalidNumberCount(existingCallRetry.getInvalidNumberCount() == null ? 0 :
                     (existingCallRetry.getInvalidNumberCount() + (invalidNr ? 1 : 0)));
@@ -307,9 +295,7 @@ LOGGER.info("this is the data inside: {},{},{]",subscription,existingCallRetry, 
         String subscriptionId = "###INVALID###";
         try {
             CallSummaryRecordDto csrDto = CallSummaryRecordDto.fromParams(event.getParameters());
-            LOGGER.info("this is csr dto : {}",csrDto);
             subscriptionId = csrDto.getSubscriptionId();
-            LOGGER.info("this is the subscriptionId: {}",subscriptionId);
             csrVerifierService.verify(csrDto);
 
             Subscription subscription = subscriptionDataService.findBySubscriptionId(subscriptionId);
@@ -318,13 +304,10 @@ LOGGER.info("this is the data inside: {},{},{]",subscription,existingCallRetry, 
             }
 
             CallRetry callRetry = callRetryDataService.findBySubscriptionId(subscriptionId);
-            LOGGER.info("this is call retry: {}",callRetry);
-            LOGGER.info("this is the final status: {}",FinalCallStatus.fromInt(csrDto.getFinalStatus()));
             switch (FinalCallStatus.fromInt(csrDto.getFinalStatus())) {
                 case SUCCESS:
                     completeSubscriptionIfNeeded(subscription, csrDto.getContentFileName());
                     if (callRetry != null) {
-
                         if (!callRetry.getContentFileName().equals("opt_in.wav")) {
                             callRetryDataService.delete(callRetry);
                         }
@@ -341,20 +324,8 @@ LOGGER.info("this is the data inside: {},{},{]",subscription,existingCallRetry, 
                     //If there was a DOB/LMP update during RCH import, number of weeks into subscription would have changed.
                     //No need to reschedule this call. Exception for w1, because regardless of which week the subscription starts in, user
                     //always gets w1 message initially
-                    LOGGER.info("this is the data: {},{}",csrDto.getWeekId(),weekId);
-
-
-
-
-                    LOGGER.info("this is data in db for week: {}",subscription.getFirstMessageDayOfWeek());
-                    LOGGER.info("this is data in csrdto: {}",DayOfTheWeek.getDayOfTheWeekFromTimestamp(csrDto.getTargetFileTimeStamp()));
-                    LOGGER.info("this is the condition1: {}",!subscription.getFirstMessageDayOfWeek().equals(DayOfTheWeek.getDayOfTheWeekFromTimestamp(csrDto.getTargetFileTimeStamp())));
-                    LOGGER.info("this is condition 2: {}", "1".equals(extractRouteNumber(csrDto.getServiceId())));
-                    LOGGER.info("this is condition 2  and return : {}",extractRouteNumber(csrDto.getServiceId()));
-                    LOGGER.info("this is service id: {}",csrDto.getServiceId());
                     if(!csrDto.getWeekId().equals("w1_1")&&!weekId.equals(csrDto.getWeekId())){
                         if(callRetry!=null){
-                            LOGGER.info("inside call retry condition");
                             callRetryDataService.delete(callRetry);
                         }
                     }else if(callRetry == null && !csrDto.getWeekId().equals("w1_1") && !subscription.getFirstMessageDayOfWeek().equals(DayOfTheWeek.getDayOfTheWeekFromTimestamp(csrDto.getTargetFileTimeStamp())) && "1".equals(extractRouteNumber(csrDto.getServiceId()))) {
@@ -365,7 +336,6 @@ LOGGER.info("this is the data inside: {},{},{]",subscription,existingCallRetry, 
                         LOGGER.info("this is the data2: {}",csrDto.getTargetFileTimeStamp());
                         if (callRetry == null ||
                                 !csrDto.getTargetFileTimeStamp().equals(callRetry.getTargetFiletimestamp())){
-                            LOGGER.info("inside fresh or retryupdate else condition");
                             doReschedule(subscription, callRetry, csrDto);
                         }
                     }
@@ -410,10 +380,8 @@ LOGGER.info("this is the data inside: {},{},{]",subscription,existingCallRetry, 
 
     private String extractRouteNumber(String serviceId) {
         if (serviceId != null && serviceId.contains("Retryonroute")) {
-            LOGGER.info("inside this1");
             int startIndex = serviceId.indexOf("Retryonroute") + "Retryonroute".length();
             if (startIndex < serviceId.length()) {
-                LOGGER.info("inside this2");
                 return String.valueOf(serviceId.charAt(startIndex));
             }
         }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
@@ -1023,6 +1023,7 @@ public class SubscriberServiceImpl implements SubscriberService {
                 return deactivatedSubscripion;
             }
         } else if (subscription != null && !subscription.getDeactivationReason().equals(DeactivationReason.INVALID_NUMBER)){
+            subscription.setModificationDate(DateTime.now());
             return subscription;
         } else {
             return subscriptionService.createSubscription(subscriber, subscriber.getCallingNumber(), language, circle, pack, origin);

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
@@ -433,7 +433,14 @@ public class SubscriberServiceImpl implements SubscriberService {
                 motherUpdate.setLastMenstrualPeriod(lmp);
                 motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
                 motherUpdate.setRegistrationDate(motherRegistrationDate);
-                if(subscription != null){subscriptionService.updateCallRetry(subscription.getSubscriptionId(),msisdn);}
+
+                if(subscription != null){
+                    if ( !((subscriberByRchId.getLastMenstrualPeriod().getDayOfYear() == lmp.getDayOfYear()) && (subscriberByRchId.getLastMenstrualPeriod().getYear() == lmp.getYear()))) {
+                        subscriptionService.deleteCallRetry(subscription.getSubscriptionId());
+                    }else {
+                        subscriptionService.updateCallRetry(subscription.getSubscriptionId(), msisdn);
+                    }
+                }
                 return updateOrCreateSubscription(subscriberByRchId, subscription, lmp, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, greaterCase);
             } else {  // we have a subscriber by phone# and also one with the RCH id
                 if (subscriptionService.activeSubscriptionByMsisdnRch(subscribersByMsisdn,msisdn, SubscriptionPackType.PREGNANCY, motherUpdate.getRchId(), null)) {
@@ -760,7 +767,13 @@ public class SubscriberServiceImpl implements SubscriberService {
                 subscriberByRchId.setDateOfBirth(dob);
                 subscriberByRchId.setModificationDate(DateTime.now());
                 // Delete that record from retry table as beneficiary gets their mobile number update
-                if(subscription != null){subscriptionService.updateCallRetry(subscription.getSubscriptionId(),msisdn);}
+                if(subscription != null){
+                    if ((subscriberByRchId.getDateOfBirth().getDayOfYear() != dob.getDayOfYear())){
+                        subscriptionService.deleteCallRetry(subscription.getSubscriptionId());
+                    }else {
+                        subscriptionService.updateCallRetry(subscription.getSubscriptionId(), msisdn);
+                    }
+                }
                 finalSubscription = updateOrCreateSubscription(subscriberByRchId, subscription, dob, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, false);
             } else {
                 //subscriber found with provided msisdn

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
@@ -433,6 +433,7 @@ public class SubscriberServiceImpl implements SubscriberService {
                 motherUpdate.setLastMenstrualPeriod(lmp);
                 motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
                 motherUpdate.setRegistrationDate(motherRegistrationDate);
+                if(subscription != null){subscriptionService.updateCallRetry(subscription.getSubscriptionId(),msisdn);}
                 return updateOrCreateSubscription(subscriberByRchId, subscription, lmp, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, greaterCase);
             } else {  // we have a subscriber by phone# and also one with the RCH id
                 if (subscriptionService.activeSubscriptionByMsisdnRch(subscribersByMsisdn,msisdn, SubscriptionPackType.PREGNANCY, motherUpdate.getRchId(), null)) {
@@ -758,6 +759,8 @@ public class SubscriberServiceImpl implements SubscriberService {
                 }
                 subscriberByRchId.setDateOfBirth(dob);
                 subscriberByRchId.setModificationDate(DateTime.now());
+                // Delete that record from retry table as beneficiary gets their mobile number update
+                if(subscription != null){subscriptionService.updateCallRetry(subscription.getSubscriptionId(),msisdn);}
                 finalSubscription = updateOrCreateSubscription(subscriberByRchId, subscription, dob, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, false);
             } else {
                 //subscriber found with provided msisdn

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
@@ -414,7 +414,7 @@ public class SubscriberServiceImpl implements SubscriberService {
                 motherUpdate.setLastMenstrualPeriod(lmp);
                 motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
                 motherUpdate.setRegistrationDate(motherRegistrationDate);
-                if(subscription != null){subscriptionService.deleteCallRetry(subscription.getSubscriptionId());}
+                if(subscription != null){subscriptionService.updateCallRetry(subscription.getSubscriptionId(),msisdn);}
                 return updateOrCreateSubscription(subscriberByRchId, subscription, lmp, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, greaterCase);
             } else {  // we have a subscriber by phone# and also one with the RCH id
                 if (subscriptionService.activeSubscriptionByMsisdnRch(subscribersByMsisdn,msisdn, SubscriptionPackType.PREGNANCY, motherUpdate.getRchId(), null)) {
@@ -732,7 +732,7 @@ public class SubscriberServiceImpl implements SubscriberService {
                 subscriberByRchId.setDateOfBirth(dob);
                 subscriberByRchId.setModificationDate(DateTime.now());
                 // Delete that record from retry table as beneficiary gets their mobile number update
-                if(subscription != null){subscriptionService.deleteCallRetry(subscription.getSubscriptionId());}
+                if(subscription != null){subscriptionService.updateCallRetry(subscription.getSubscriptionId(),msisdn);}
                 finalSubscription = updateOrCreateSubscription(subscriberByRchId, subscription, dob, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, false);
             } else {
                 //subscriber found with provided msisdn

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
@@ -407,6 +407,25 @@ public class SubscriberServiceImpl implements SubscriberService {
                     subscriberByRchId.setCaseNo(caseNo);
                     motherUpdate.setMaxCaseNo(caseNo);
                 }
+
+
+                if(subscription != null){
+                    LOGGER.info("we are inside not null condition");
+                    LOGGER.info("1st value: {}",subscriberByRchId.getLastMenstrualPeriod().getDayOfYear());
+                    LOGGER.info("second value: {}",lmp.getDayOfYear());
+                    LOGGER.info("third value: {}",subscriberByRchId.getLastMenstrualPeriod().getYear());
+                    LOGGER.info("second value: {}",lmp.getYear());
+                    LOGGER.info("this is the first case: {}",(subscriberByRchId.getLastMenstrualPeriod().getDayOfYear() == lmp.getDayOfYear()));
+                    LOGGER.info("this is the second case2: {}",(subscriberByRchId.getLastMenstrualPeriod().getYear() == lmp.getYear()));
+                    if ( !((subscriberByRchId.getLastMenstrualPeriod().getDayOfYear() == lmp.getDayOfYear()) && (subscriberByRchId.getLastMenstrualPeriod().getYear() == lmp.getYear()))) {
+                        LOGGER.info("inside delete condition");
+                        subscriptionService.deleteCallRetry(subscription.getSubscriptionId());
+
+                    }else {
+                        LOGGER.info("we are inside else null condition");
+                        subscriptionService.updateCallRetry(subscription.getSubscriptionId(), msisdn);
+                    }
+                }
                 subscriberByRchId.setLastMenstrualPeriod(lmp);
                 subscriberByRchId.setModificationDate(DateTime.now());
                 motherUpdate.setName(name);
@@ -414,14 +433,6 @@ public class SubscriberServiceImpl implements SubscriberService {
                 motherUpdate.setLastMenstrualPeriod(lmp);
                 motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
                 motherUpdate.setRegistrationDate(motherRegistrationDate);
-
-                if(subscription != null){
-                    if ( !((subscriberByRchId.getLastMenstrualPeriod().getDayOfYear() == lmp.getDayOfYear()) && (subscriberByRchId.getLastMenstrualPeriod().getYear() == lmp.getYear()))) {
-                        subscriptionService.deleteCallRetry(subscription.getSubscriptionId());
-                    }else {
-                        subscriptionService.updateCallRetry(subscription.getSubscriptionId(), msisdn);
-                    }
-                }
                 return updateOrCreateSubscription(subscriberByRchId, subscription, lmp, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, greaterCase);
             } else {  // we have a subscriber by phone# and also one with the RCH id
                 if (subscriptionService.activeSubscriptionByMsisdnRch(subscribersByMsisdn,msisdn, SubscriptionPackType.PREGNANCY, motherUpdate.getRchId(), null)) {
@@ -736,8 +747,7 @@ public class SubscriberServiceImpl implements SubscriberService {
                     subscription = latestDeactivatedSubscription;
                      }
                 }
-                subscriberByRchId.setDateOfBirth(dob);
-                subscriberByRchId.setModificationDate(DateTime.now());
+
                 // Delete that record from retry table as beneficiary gets their mobile number update
                 if(subscription != null){
                     if ((subscriberByRchId.getDateOfBirth().getDayOfYear() != dob.getDayOfYear())){
@@ -746,6 +756,8 @@ public class SubscriberServiceImpl implements SubscriberService {
                         subscriptionService.updateCallRetry(subscription.getSubscriptionId(), msisdn);
                     }
                 }
+                subscriberByRchId.setDateOfBirth(dob);
+                subscriberByRchId.setModificationDate(DateTime.now());
                 finalSubscription = updateOrCreateSubscription(subscriberByRchId, subscription, dob, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, false);
             } else {
                 //subscriber found with provided msisdn

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
@@ -1023,6 +1023,10 @@ public class SubscriberServiceImpl implements SubscriberService {
                 return deactivatedSubscripion;
             }
         } else if (subscription != null && !subscription.getDeactivationReason().equals(DeactivationReason.INVALID_NUMBER)){
+            Set<Subscription> activeSubscriptions = subscriber.getActiveAndPendingSubscriptions();
+            if (activeSubscriptions != null && !activeSubscriptions.isEmpty()) {
+                activeSubscriptions.forEach(sub -> sub.setModificationDate(DateTime.now()));
+            }
             subscription.setModificationDate(DateTime.now());
             return subscription;
         } else {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
@@ -433,14 +433,6 @@ public class SubscriberServiceImpl implements SubscriberService {
                 motherUpdate.setLastMenstrualPeriod(lmp);
                 motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
                 motherUpdate.setRegistrationDate(motherRegistrationDate);
-
-                if(subscription != null){
-                    if ( !((subscriberByRchId.getLastMenstrualPeriod().getDayOfYear() == lmp.getDayOfYear()) && (subscriberByRchId.getLastMenstrualPeriod().getYear() == lmp.getYear()))) {
-                        subscriptionService.deleteCallRetry(subscription.getSubscriptionId());
-                    }else {
-                        subscriptionService.updateCallRetry(subscription.getSubscriptionId(), msisdn);
-                    }
-                }
                 return updateOrCreateSubscription(subscriberByRchId, subscription, lmp, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, greaterCase);
             } else {  // we have a subscriber by phone# and also one with the RCH id
                 if (subscriptionService.activeSubscriptionByMsisdnRch(subscribersByMsisdn,msisdn, SubscriptionPackType.PREGNANCY, motherUpdate.getRchId(), null)) {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
@@ -414,7 +414,14 @@ public class SubscriberServiceImpl implements SubscriberService {
                 motherUpdate.setLastMenstrualPeriod(lmp);
                 motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
                 motherUpdate.setRegistrationDate(motherRegistrationDate);
-                if(subscription != null){subscriptionService.updateCallRetry(subscription.getSubscriptionId(),msisdn);}
+
+                if(subscription != null){
+                    if ( !((subscriberByRchId.getLastMenstrualPeriod().getDayOfYear() == lmp.getDayOfYear()) && (subscriberByRchId.getLastMenstrualPeriod().getYear() == lmp.getYear()))) {
+                        subscriptionService.deleteCallRetry(subscription.getSubscriptionId());
+                    }else {
+                        subscriptionService.updateCallRetry(subscription.getSubscriptionId(), msisdn);
+                    }
+                }
                 return updateOrCreateSubscription(subscriberByRchId, subscription, lmp, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, greaterCase);
             } else {  // we have a subscriber by phone# and also one with the RCH id
                 if (subscriptionService.activeSubscriptionByMsisdnRch(subscribersByMsisdn,msisdn, SubscriptionPackType.PREGNANCY, motherUpdate.getRchId(), null)) {
@@ -732,7 +739,13 @@ public class SubscriberServiceImpl implements SubscriberService {
                 subscriberByRchId.setDateOfBirth(dob);
                 subscriberByRchId.setModificationDate(DateTime.now());
                 // Delete that record from retry table as beneficiary gets their mobile number update
-                if(subscription != null){subscriptionService.updateCallRetry(subscription.getSubscriptionId(),msisdn);}
+                if(subscription != null){
+                    if ((subscriberByRchId.getDateOfBirth().getDayOfYear() != dob.getDayOfYear())){
+                        subscriptionService.deleteCallRetry(subscription.getSubscriptionId());
+                    }else {
+                        subscriptionService.updateCallRetry(subscription.getSubscriptionId(), msisdn);
+                    }
+                }
                 finalSubscription = updateOrCreateSubscription(subscriberByRchId, subscription, dob, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, false);
             } else {
                 //subscriber found with provided msisdn

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
@@ -410,13 +410,6 @@ public class SubscriberServiceImpl implements SubscriberService {
 
 
                 if(subscription != null){
-                    LOGGER.info("we are inside not null condition");
-                    LOGGER.info("1st value: {}",subscriberByRchId.getLastMenstrualPeriod().getDayOfYear());
-                    LOGGER.info("second value: {}",lmp.getDayOfYear());
-                    LOGGER.info("third value: {}",subscriberByRchId.getLastMenstrualPeriod().getYear());
-                    LOGGER.info("second value: {}",lmp.getYear());
-                    LOGGER.info("this is the first case: {}",(subscriberByRchId.getLastMenstrualPeriod().getDayOfYear() == lmp.getDayOfYear()));
-                    LOGGER.info("this is the second case2: {}",(subscriberByRchId.getLastMenstrualPeriod().getYear() == lmp.getYear()));
                     if ( !((subscriberByRchId.getLastMenstrualPeriod().getDayOfYear() == lmp.getDayOfYear()) && (subscriberByRchId.getLastMenstrualPeriod().getYear() == lmp.getYear()))) {
                         LOGGER.info("inside delete condition");
                         subscriptionService.deleteCallRetry(subscription.getSubscriptionId());

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
@@ -1025,7 +1025,9 @@ public class SubscriberServiceImpl implements SubscriberService {
         } else if (subscription != null && !subscription.getDeactivationReason().equals(DeactivationReason.INVALID_NUMBER)){
             Set<Subscription> activeSubscriptions = subscriber.getActiveAndPendingSubscriptions();
             if (activeSubscriptions != null && !activeSubscriptions.isEmpty()) {
-                activeSubscriptions.forEach(sub -> sub.setModificationDate(DateTime.now()));
+                for(Subscription sub : activeSubscriptions ){
+                    sub.setModificationDate(DateTime.now());
+                }
             }
             subscription.setModificationDate(DateTime.now());
             return subscription;

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
@@ -411,11 +411,9 @@ public class SubscriberServiceImpl implements SubscriberService {
 
                 if(subscription != null){
                     if ( !((subscriberByRchId.getLastMenstrualPeriod().getDayOfYear() == lmp.getDayOfYear()) && (subscriberByRchId.getLastMenstrualPeriod().getYear() == lmp.getYear()))) {
-                        LOGGER.info("inside delete condition");
                         subscriptionService.deleteCallRetry(subscription.getSubscriptionId());
 
                     }else {
-                        LOGGER.info("we are inside else null condition");
                         subscriptionService.updateCallRetry(subscription.getSubscriptionId(), msisdn);
                     }
                 }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriptionServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriptionServiceImpl.java
@@ -945,6 +945,15 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     }
 
     @Override
+    public void updateCallRetry(String subscriptionId,Long msisdn) {
+        CallRetry callRetry = callRetryDataService.findBySubscriptionId(subscriptionId);
+        if (callRetry != null) {
+            callRetry.setMsisdn(msisdn);
+            callRetryDataService.update(callRetry);
+        }
+    }
+
+    @Override
     public void deactivateSubscription(Subscription subscription, DeactivationReason reason) {
         if (subscription != null && (subscription.getStatus() == SubscriptionStatus.ACTIVE ||
                 subscription.getStatus() == SubscriptionStatus.PENDING_ACTIVATION || subscription.getStatus() == SubscriptionStatus.HOLD)) {

--- a/props/src/main/java/org/motechproject/nms/props/domain/DayOfTheWeek.java
+++ b/props/src/main/java/org/motechproject/nms/props/domain/DayOfTheWeek.java
@@ -1,6 +1,8 @@
 package org.motechproject.nms.props.domain;
 
 import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 
 public enum DayOfTheWeek {
     MONDAY(1),
@@ -36,6 +38,16 @@ public enum DayOfTheWeek {
 
     public static DayOfTheWeek fromDateTime(DateTime dt) {
         return fromInt(dt.getDayOfWeek());
+    }
+
+    public static DayOfTheWeek getDayOfTheWeekFromTimestamp(String timestamp) {
+        DateTimeFormatter formatter = DateTimeFormat.forPattern("yyyyMMddHHmmss");
+
+        DateTime dateTime = formatter.parseDateTime(timestamp);
+
+        int dayOfWeek = dateTime.getDayOfWeek(); // 1 = Monday, 7 = Sunday
+
+        return DayOfTheWeek.fromInt(dayOfWeek);
     }
 
     public DayOfTheWeek nextDay() {


### PR DESCRIPTION
Made changes to prevent duplicate records in the OBD file when we receive an update from RCH for the LMP date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for including a service ID in call summary records, enabling more detailed tracking and reporting.
  * Introduced the ability to update call retry information for subscriptions, allowing for more flexible management of call retries.
  * Added a utility to extract the day of the week from a timestamp for improved scheduling and reporting.

* **Improvements**
  * Refined logic for updating or deleting call retry records based on subscriber data changes, improving accuracy in retry handling.
  * Updated modification dates for all active subscriptions when an existing subscription is returned, ensuring more consistent record-keeping.
  * Enhanced call retry synchronization with subscriber contact details during rescheduling.
  * Improved failed call handling with route-based differentiation and logging for better diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->